### PR TITLE
feat(impl):[TRI-869] single level usage as built coverage

### DIFF
--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/registry/domain/AssetAdministrationShellTestdataCreator.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/registry/domain/AssetAdministrationShellTestdataCreator.java
@@ -39,6 +39,7 @@ import org.springframework.web.client.RestClientException;
  * Class to create AssetAdministrationShell Testdata
  * As AASWrapper is not deployed, we are using this class to Stub responses
  */
+@SuppressWarnings({ "PMD.TooManyMethods" })
 class AssetAdministrationShellTestdataCreator {
 
     private final CxTestDataContainer cxTestDataContainer;
@@ -57,6 +58,7 @@ class AssetAdministrationShellTestdataCreator {
         final List<SubmodelDescriptor> submodelDescriptors = new ArrayList<>();
         cxTestData.get().getAssemblyPartRelationship().ifPresent(submodel -> submodelDescriptors.add(createAssemblyPartRelationshipSubmodelDescriptor(catenaXId)));
         cxTestData.get().getSerialPartTypization().ifPresent(submodel -> submodelDescriptors.add(createSerialPartTypizationSubmodelDescriptor(catenaXId)));
+        cxTestData.get().getSingleLevelUsageAsBuilt().ifPresent(submodel -> submodelDescriptors.add(createSingleLevelUsageAsBuiltSubmodelDescriptor(catenaXId)));
         cxTestData.get().getSingleLevelBomAsPlanned().ifPresent(submodel -> submodelDescriptors.add(createSingleLevelBomAsPlannedSubmodelDescriptor(catenaXId)));
         cxTestData.get().getPartAsPlanned().ifPresent(submodel -> submodelDescriptors.add(createPartAsPlannedSubmodelDescriptor(catenaXId)));
         cxTestData.get().getBatch().ifPresent(submodel -> submodelDescriptors.add(createBatchSubmodelDescriptor(catenaXId)));
@@ -78,6 +80,11 @@ class AssetAdministrationShellTestdataCreator {
     private SubmodelDescriptor createAssemblyPartRelationshipSubmodelDescriptor(final String catenaXId) {
         return createSubmodelDescriptor(catenaXId, "urn:bamm:io.catenax.assembly_part_relationship:1.0.0",
                 "assemblyPartRelationship");
+    }
+
+    private SubmodelDescriptor createSingleLevelUsageAsBuiltSubmodelDescriptor(final String catenaXId) {
+        return createSubmodelDescriptor(catenaXId, "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0",
+                "singleLevelUsageAsBuilt");
     }
 
     private SubmodelDescriptor createSerialPartTypizationSubmodelDescriptor(final String catenaXId) {

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/local/CxTestDataContainer.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/local/CxTestDataContainer.java
@@ -56,6 +56,8 @@ public class CxTestDataContainer {
         private List<Map<String, Object>> serialPartTypization;
         @JsonProperty("urn:bamm:io.catenax.assembly_part_relationship:1.1.1#AssemblyPartRelationship")
         private List<Map<String, Object>> assemblyPartRelationship;
+        @JsonProperty("urn:bamm:io.catenax.single_level_usage_as_built:1.0.1#SingleLevelUsageAsBuilt")
+        private List<Map<String, Object>> singleLevelUsageAsBuilt;
         @JsonProperty("urn:bamm:io.catenax.part_as_planned:1.0.0#PartAsPlanned")
         private List<Map<String, Object>> partAsPlanned;
         @JsonProperty("urn:bamm:io.catenax.single_level_bom_as_planned:1.0.2#SingleLevelBomAsPlanned")
@@ -75,6 +77,10 @@ public class CxTestDataContainer {
 
         public Optional<Map<String, Object>> getAssemblyPartRelationship() {
             return assemblyPartRelationship != null ? assemblyPartRelationship.stream().findFirst() : Optional.empty();
+        }
+
+        public Optional<Map<String, Object>> getSingleLevelUsageAsBuilt() {
+            return singleLevelUsageAsBuilt != null ? singleLevelUsageAsBuilt.stream().findFirst() : Optional.empty();
         }
 
         public Optional<Map<String, Object>> getPartAsPlanned() {

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/edc/SubmodelTestdataCreator.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/edc/SubmodelTestdataCreator.java
@@ -50,13 +50,16 @@ class SubmodelTestdataCreator {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
+    @SuppressWarnings({ "PMD.CyclomaticComplexity" })
     public Map<String, Object> createSubmodelForId(final String endpointAddress) {
         final String catenaXId = StringUtils.substringBefore(endpointAddress, "_");
         if (endpointAddress.contains("assemblyPartRelationship")) {
             return this.cxTestDataContainer.getByCatenaXId(catenaXId).flatMap(CxTestDataContainer.CxTestData::getAssemblyPartRelationship).orElse(Map.of());
+        } else if (endpointAddress.contains("singleLevelUsageAsBuilt")) {
+            return this.cxTestDataContainer.getByCatenaXId(catenaXId).flatMap(CxTestDataContainer.CxTestData::getSingleLevelUsageAsBuilt).orElse(Map.of());
         } else if (endpointAddress.contains("serialPartTypization")) {
             return this.cxTestDataContainer.getByCatenaXId(catenaXId).flatMap(CxTestDataContainer.CxTestData::getSerialPartTypization).orElse(Map.of());
-        }  else if (endpointAddress.contains("singleLevelBomAsPlanned")) {
+        } else if (endpointAddress.contains("singleLevelBomAsPlanned")) {
             return this.cxTestDataContainer.getByCatenaXId(catenaXId).flatMap(CxTestDataContainer.CxTestData::getSingleLevelBomAsPlanned).orElse(Map.of());
         } else if (endpointAddress.contains("partAsPlanned")) {
             return this.cxTestDataContainer.getByCatenaXId(catenaXId).flatMap(CxTestDataContainer.CxTestData::getPartAsPlanned).orElse(Map.of());


### PR DESCRIPTION
Upward direction with SingleLevelUsageAsBult tests