### PR TITLE
feat(impl):[TRI-798] move checking depth to delegate

### DIFF
--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASRecursiveJobHandler.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASRecursiveJobHandler.java
@@ -24,7 +24,6 @@ package org.eclipse.tractusx.irs.aaswrapper.job;
 import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.tractusx.irs.component.JobParameter;
 import org.eclipse.tractusx.irs.connector.job.MultiTransferJob;
 import org.eclipse.tractusx.irs.connector.job.RecursiveJobHandler;
 
@@ -52,17 +51,9 @@ public class AASRecursiveJobHandler implements RecursiveJobHandler<ItemDataReque
     public Stream<ItemDataRequest> recurse(final MultiTransferJob job, final AASTransferProcess transferProcess) {
         log.info("Starting recursive request for job {}", job.getJobIdString());
 
-        final JobParameter jobParameter = job.getJobParameter();
-        final int expectedDepth = jobParameter.getDepth();
-        final Integer currentDepth = transferProcess.getDepth();
-
-        if (expectedDepthOfTreeIsNotReached(expectedDepth, currentDepth)) {
-            return transferProcess.getIdsToProcess()
-                                  .stream()
-                                  .map(itemId -> ItemDataRequest.nextDepthNode(itemId, currentDepth));
-        }
-
-        return Stream.empty();
+        return transferProcess.getIdsToProcess()
+                              .stream()
+                              .map(itemId -> ItemDataRequest.nextDepthNode(itemId, transferProcess.getDepth()));
     }
 
     @Override
@@ -73,8 +64,4 @@ public class AASRecursiveJobHandler implements RecursiveJobHandler<ItemDataReque
         logic.assemblePartialItemGraphBlobs(completedTransfers, targetBlobName.toString());
     }
 
-    private boolean expectedDepthOfTreeIsNotReached(final Integer expectedDepth, final Integer currentDepth) {
-        log.info("Expected tree depth is {}, current depth is {}", expectedDepth, currentDepth);
-        return currentDepth < expectedDepth;
-    }
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegate.java
@@ -47,7 +47,7 @@ public class BpdmDelegate extends AbstractDelegate {
 
     public BpdmDelegate(final AbstractDelegate nextStep,
             final BpdmFacade bpdmFacade) {
-        super(nextStep); // no next step
+        super(nextStep);
         this.bpdmFacade = bpdmFacade;
     }
 

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegate.java
@@ -102,7 +102,7 @@ public class BpdmDelegate extends AbstractDelegate {
 
     private boolean expectedDepthOfTreeIsNotReached(final int expectedDepth, final int currentDepth) {
         log.info("Expected tree depth is {}, current depth is {}", expectedDepth, currentDepth);
-        return currentDepth <= expectedDepth;
+        return currentDepth < expectedDepth;
     }
 
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegate.java
@@ -60,10 +60,10 @@ public class SubmodelDelegate extends AbstractDelegate {
     private final JsonValidatorService jsonValidatorService;
     private final JsonUtil jsonUtil;
 
-    public SubmodelDelegate(final AbstractDelegate nextStep, final EdcSubmodelFacade submodelFacade,
+    public SubmodelDelegate(final EdcSubmodelFacade submodelFacade,
             final SemanticsHubFacade semanticsHubFacade, final JsonValidatorService jsonValidatorService,
             final JsonUtil jsonUtil) {
-        super(nextStep);
+        super(null); // no next step
         this.submodelFacade = submodelFacade;
         this.semanticsHubFacade = semanticsHubFacade;
         this.jsonValidatorService = jsonValidatorService;

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
@@ -109,9 +109,15 @@ public class JobConfiguration {
     }
 
     @Bean
-    public DigitalTwinDelegate digitalTwinDelegate(final RelationshipDelegate relationshipDelegate,
+    public DigitalTwinDelegate digitalTwinDelegate(final BpdmDelegate bpdmDelegate,
             final DigitalTwinRegistryFacade digitalTwinRegistryFacade) {
-        return new DigitalTwinDelegate(relationshipDelegate, digitalTwinRegistryFacade);
+        return new DigitalTwinDelegate(bpdmDelegate, digitalTwinRegistryFacade);
+    }
+
+    @Bean
+    public BpdmDelegate bpdmDelegate(final RelationshipDelegate relationshipDelegate,
+            final BpdmFacade bpdmFacade) {
+        return new BpdmDelegate(relationshipDelegate, bpdmFacade);
     }
 
     @Bean
@@ -121,15 +127,9 @@ public class JobConfiguration {
     }
 
     @Bean
-    public SubmodelDelegate submodelDelegate(final BpdmDelegate bpdmDelegate, final EdcSubmodelFacade submodelFacade,
+    public SubmodelDelegate submodelDelegate(final EdcSubmodelFacade submodelFacade,
             final SemanticsHubFacade semanticsHubFacade, final JsonValidatorService jsonValidatorService) {
-        return new SubmodelDelegate(bpdmDelegate, submodelFacade, semanticsHubFacade, jsonValidatorService, jsonUtil());
+        return new SubmodelDelegate(submodelFacade, semanticsHubFacade, jsonValidatorService, jsonUtil());
     }
-
-    @Bean
-    public BpdmDelegate bpdmDelegate(final BpdmFacade bpdmFacade) {
-        return new BpdmDelegate(bpdmFacade);
-    }
-
 
 }

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateTest.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import org.eclipse.tractusx.irs.aaswrapper.job.AASTransferProcess;
 import org.eclipse.tractusx.irs.aaswrapper.job.ItemContainer;
 import org.eclipse.tractusx.irs.bpdm.BpdmFacade;
-import org.eclipse.tractusx.irs.component.JobParameter;
 import org.eclipse.tractusx.irs.component.assetadministrationshell.AssetAdministrationShellDescriptor;
 import org.eclipse.tractusx.irs.component.assetadministrationshell.IdentifierKeyValuePair;
 import org.eclipse.tractusx.irs.component.enums.ProcessStep;
@@ -46,7 +45,7 @@ import org.springframework.web.client.RestClientException;
 class BpdmDelegateTest {
 
     final BpdmFacade bpdmFacade = mock(BpdmFacade.class);
-    final BpdmDelegate bpdmDelegate = new BpdmDelegate(bpdmFacade);
+    final BpdmDelegate bpdmDelegate = new BpdmDelegate(null, bpdmFacade);
 
     @Test
     void shouldFillItemContainerWithBpn() {
@@ -57,7 +56,7 @@ class BpdmDelegateTest {
 
         // when
         final ItemContainer result = bpdmDelegate.process(itemContainerWithShell, jobParameter(),
-                new AASTransferProcess(), "itemId");
+                new AASTransferProcess("id", 0), "itemId");
 
         // then
         assertThat(result).isNotNull();
@@ -73,7 +72,7 @@ class BpdmDelegateTest {
 
         // when
         final ItemContainer result = bpdmDelegate.process(itemContainerWithShell, jobParameter(),
-                new AASTransferProcess(), "itemId");
+                new AASTransferProcess("id", 0), "itemId");
 
         // then
         assertThat(result).isNotNull();
@@ -92,7 +91,7 @@ class BpdmDelegateTest {
 
         // when
         final ItemContainer result = bpdmDelegate.process(itemContainerWithShell, jobParameter(),
-                new AASTransferProcess(), "itemId");
+                new AASTransferProcess("id", 0), "itemId");
 
         // then
         assertThat(result).isNotNull();
@@ -111,7 +110,7 @@ class BpdmDelegateTest {
 
         // when
         final ItemContainer result = bpdmDelegate.process(itemContainerWithShell, jobParameter(),
-                new AASTransferProcess(), "itemId");
+                new AASTransferProcess("id", 0), "itemId");
 
         // then
         assertThat(result).isNotNull();
@@ -129,7 +128,7 @@ class BpdmDelegateTest {
 
         // when
         final ItemContainer result = bpdmDelegate.process(itemContainerWithShell, jobParameter(),
-                new AASTransferProcess(), "itemId");
+                new AASTransferProcess("id", 0), "itemId");
 
         // then
         assertThat(result).isNotNull();
@@ -147,7 +146,7 @@ class BpdmDelegateTest {
 
         // when
         final ItemContainer result = bpdmDelegate.process(itemContainerWithoutShell, jobParameter(),
-                new AASTransferProcess(), "itemId");
+                new AASTransferProcess("id", 0), "itemId");
 
         // then
         assertThat(result).isNotNull();

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegateTest.java
@@ -48,7 +48,7 @@ class SubmodelDelegateTest {
     final EdcSubmodelFacade submodelFacade = mock(EdcSubmodelFacade.class);
     final SemanticsHubFacade semanticsHubFacade = mock(SemanticsHubFacade.class);
     final JsonValidatorService jsonValidatorService = mock(JsonValidatorService.class);
-    final SubmodelDelegate submodelDelegate = new SubmodelDelegate(null, submodelFacade,
+    final SubmodelDelegate submodelDelegate = new SubmodelDelegate(submodelFacade,
             semanticsHubFacade, jsonValidatorService, new JsonUtil());
 
     @Test

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceSpringBootTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceSpringBootTest.java
@@ -100,7 +100,7 @@ class IrsItemGraphQueryServiceSpringBootTest {
     void registerJobWithCollectAspectsShouldIncludeSubmodels() throws InvalidSchemaException {
         // given
         when(jsonValidatorService.validate(any(), any())).thenReturn(ValidationResult.builder().valid(true).build());
-        final RegisterJob registerJob = registerJobWithGlobalAssetIdAndDepth("urn:uuid:4132cd2b-cbe7-4881-a6b4-39fdc31cca2b", 0,
+        final RegisterJob registerJob = registerJobWithGlobalAssetIdAndDepth("urn:uuid:4132cd2b-cbe7-4881-a6b4-39fdc31cca2b", 100,
                 List.of(AspectType.SERIAL_PART_TYPIZATION, AspectType.PRODUCT_DESCRIPTION, AspectType.ASSEMBLY_PART_RELATIONSHIP), true);
         final int expectedSubmodelsSizeFullTree = 3; // stub
 
@@ -135,7 +135,7 @@ class IrsItemGraphQueryServiceSpringBootTest {
     @Test
     void registerJobWithDepthShouldBuildTreeUntilGivenDepth() {
         // given
-        final RegisterJob registerJob = registerJobWithDepthAndAspect(0, null);
+        final RegisterJob registerJob = registerJobWithDepthAndAspect(1, null);
         final int expectedRelationshipsSizeFirstDepth = 1; // stub
 
         // when


### PR DESCRIPTION
- move checking depth to delegate - so no more relationships/submodels are retrieved, but only Shells + BPN's
- submodel delegate is now the last one (previously bpdm delegate)