### PR TITLE
chore(owasp):[-] Update OWASP Dependency Check Plugin to 7.4.4 to fix…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B clean package -pl :$BUILD_TARGET 
 # Copy the jar and build image
 FROM eclipse-temurin:19-jre-alpine AS irs-api
 
-RUN apk update && apk upgrade -a
+RUN apk upgrade
 
 ARG UID=10000
 ARG GID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B clean package -pl :$BUILD_TARGET 
 # Copy the jar and build image
 FROM eclipse-temurin:19-jre-alpine AS irs-api
 
-RUN apk upgrade
+RUN apk update && apk upgrade -a
 
 ARG UID=10000
 ARG GID=1000

--- a/ci/owasp-suppressions.xml
+++ b/ci/owasp-suppressions.xml
@@ -83,6 +83,20 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
+        IRS is not parsing user YAML input, thus this CVE is irrelevant.
+        ]]></notes>
+        <gav regex="true">org\.yaml:snakeyaml.*</gav>
+        <vulnerabilityName>CVE-2021-4235</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        IRS is not parsing user YAML input, thus this CVE is irrelevant.
+        ]]></notes>
+        <gav regex="true">org\.yaml:snakeyaml.*</gav>
+        <vulnerabilityName>CVE-2022-3064</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
         Only relevant if UNWRAP_SINGLE_VALUE_ARRAYS is activated, which is not the case here.
         ]]></notes>
         <gav regex="true">com\.fasterxml\.jackson\.core:jackson-databind.*</gav>

--- a/ci/owasp-suppressions.xml
+++ b/ci/owasp-suppressions.xml
@@ -102,4 +102,11 @@
         <gav regex="true">com\.fasterxml\.jackson\.core:jackson-databind.*</gav>
         <vulnerabilityName>CVE-2022-42003</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Accepted - potentially vulnerable library is only used in metric actuator, which is not reachable from outside.
+        ]]></notes>
+        <gav regex="true">org\.latencyutils.*</gav>
+        <vulnerabilityName>CVE-2021-4277</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <checkstyle.version>10.4</checkstyle.version>
         <jacoco.version>0.8.8</jacoco.version>
         <pmd-plugin.version>3.19.0</pmd-plugin.version>
-        <owasp-plugin.version>7.3.0</owasp-plugin.version>
+        <owasp-plugin.version>7.4.4</owasp-plugin.version>
 
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <jar-plugin.version>3.3.0</jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         </sonar.coverage.jacoco.xmlReportPaths>
 
         <!-- Dependencies -->
-        <springboot.version>2.7.5</springboot.version>
+        <springboot.version>2.7.7</springboot.version>
         <springcloud-feign.version>3.1.5</springcloud-feign.version>
         <springdoc.version>1.6.7</springdoc.version>
         <micrometer.version>1.10.0</micrometer.version>


### PR DESCRIPTION
Updated OWASP Dependency Check Plugin to 7.4.4 to fix DB error.

Also updated Spring Boot to 2.7.7 to fix vulnerable libraries.

Irrelevant findings are suppressed.