### PR TITLE
feat(impl):[TRI-998] merge other repo PR - fix security findings

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -48,8 +48,8 @@ jobs:
           # token: ${{ secrets.GITHUB_TOKEN }}
           # enable_comments: true
           # Exclude accepted results from the build
-          exclude_results: "dda6420c385b33bef69f4db723fee4f469c93e851370c868a15af9bce5b3ec44,\ # docker-compose.yml - local env minio password 
-            03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795" # application-local.yml - local env minio password
+          exclude_results: "dda6420c385b33bef69f4db723fee4f469c93e851370c868a15af9bce5b3ec44,\
+            03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795" # docker-compose.yml + application-local.yml - local env minio password
           # Exclude accepted queries from the build
           #exclude_queries: ""
 

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -32,8 +32,7 @@ jobs:
           # Scanning directory .
           path: "."
           # Exclude paths or files from scan
-          # exclude_paths: "api/irs-v1.0.yaml"
-          exclude_paths: api-tests/irs-api-tests.tavern.yaml,charts/irs-environments/local/*
+          exclude_paths: api/irs-v1.0.yaml,api-tests/irs-api-tests.tavern.yaml,charts/irs-environments/local/*
           # Fail on HIGH severity results
           fail_on: high
           # when provided with a directory on output_path
@@ -49,22 +48,22 @@ jobs:
           # token: ${{ secrets.GITHUB_TOKEN }}
           # enable_comments: true
           # Exclude accepted results from the build
-          exclude_results: "dda6420c385b33bef69f4db723fee4f469c93e851370c868a15af9bce5b3ec44,\
-            03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795,\
-            cd97103ed4e69cbeea5097168f744fdeffade5f6a5bf0b0f0b6bdaaa91b6815e,\
-            724d6b5be1557dd1a6a2fb0e5c10ec0bcca20092c02fafad544c19a0b6d0e38f,\
-            b8f92f3e5419d7e0bdefd956549b372fec72affbb25b735cbc59f0e9762f6943,\
-            9cc9972d007cadc1b17d7ff64eb9aa66648c32997279c5b80c411abbcfbf3c5a,\
-            663dfa114d46fb8eebf7e98ff0ba3f60f80b8059f8c170c12b07feb909b36f19,\
-            edc4c9ac9ee139c0d7947410439b66e3c6290cb97a37d97a7519d3d5e56a5a84,\
-            7f3e9461a3abdb7a281fdc736fb0827e69e9278ccd6b929bd32fc2d84336f68c,\
-            10e4fff1f26f0a765423e35a7d8952363a6e8961a58e20b3017cd7818745eb36"
-          # Exclude accepted queries from the build
-          exclude_queries: "9f88c88d-824d-4d9a-b985-e22977046042,\
-          00b78adf-b83f-419c-8ed8-c6018441dd3a,\
-          8c8261c2-19a9-4ef7-ad37-b8bc7bdd4d85,\
-          8c81d6c0-716b-49ec-afa5-2d62da4e3f3c,\
-          2d8c175a-6d90-412b-8b0e-e034ea49a1fe"
+#          exclude_results: "dda6420c385b33bef69f4db723fee4f469c93e851370c868a15af9bce5b3ec44,\
+#            03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795,\
+#            cd97103ed4e69cbeea5097168f744fdeffade5f6a5bf0b0f0b6bdaaa91b6815e,\
+#            724d6b5be1557dd1a6a2fb0e5c10ec0bcca20092c02fafad544c19a0b6d0e38f,\
+#            b8f92f3e5419d7e0bdefd956549b372fec72affbb25b735cbc59f0e9762f6943,\
+#            9cc9972d007cadc1b17d7ff64eb9aa66648c32997279c5b80c411abbcfbf3c5a,\
+#            663dfa114d46fb8eebf7e98ff0ba3f60f80b8059f8c170c12b07feb909b36f19,\
+#            edc4c9ac9ee139c0d7947410439b66e3c6290cb97a37d97a7519d3d5e56a5a84,\
+#            7f3e9461a3abdb7a281fdc736fb0827e69e9278ccd6b929bd32fc2d84336f68c,\
+#            10e4fff1f26f0a765423e35a7d8952363a6e8961a58e20b3017cd7818745eb36"
+#          # Exclude accepted queries from the build
+#          exclude_queries: "9f88c88d-824d-4d9a-b985-e22977046042,\
+#          00b78adf-b83f-419c-8ed8-c6018441dd3a,\
+#          8c8261c2-19a9-4ef7-ad37-b8bc7bdd4d85,\
+#          8c81d6c0-716b-49ec-afa5-2d62da4e3f3c,\
+#          2d8c175a-6d90-412b-8b0e-e034ea49a1fe"
 
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -48,22 +48,10 @@ jobs:
           # token: ${{ secrets.GITHUB_TOKEN }}
           # enable_comments: true
           # Exclude accepted results from the build
-#          exclude_results: "dda6420c385b33bef69f4db723fee4f469c93e851370c868a15af9bce5b3ec44,\
-#            03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795,\
-#            cd97103ed4e69cbeea5097168f744fdeffade5f6a5bf0b0f0b6bdaaa91b6815e,\
-#            724d6b5be1557dd1a6a2fb0e5c10ec0bcca20092c02fafad544c19a0b6d0e38f,\
-#            b8f92f3e5419d7e0bdefd956549b372fec72affbb25b735cbc59f0e9762f6943,\
-#            9cc9972d007cadc1b17d7ff64eb9aa66648c32997279c5b80c411abbcfbf3c5a,\
-#            663dfa114d46fb8eebf7e98ff0ba3f60f80b8059f8c170c12b07feb909b36f19,\
-#            edc4c9ac9ee139c0d7947410439b66e3c6290cb97a37d97a7519d3d5e56a5a84,\
-#            7f3e9461a3abdb7a281fdc736fb0827e69e9278ccd6b929bd32fc2d84336f68c,\
-#            10e4fff1f26f0a765423e35a7d8952363a6e8961a58e20b3017cd7818745eb36"
-#          # Exclude accepted queries from the build
-#          exclude_queries: "9f88c88d-824d-4d9a-b985-e22977046042,\
-#          00b78adf-b83f-419c-8ed8-c6018441dd3a,\
-#          8c8261c2-19a9-4ef7-ad37-b8bc7bdd4d85,\
-#          8c81d6c0-716b-49ec-afa5-2d62da4e3f3c,\
-#          2d8c175a-6d90-412b-8b0e-e034ea49a1fe"
+          exclude_results: "dda6420c385b33bef69f4db723fee4f469c93e851370c868a15af9bce5b3ec44,\ # docker-compose.yml - local env minio password 
+            03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795" # application-local.yml - local env minio password
+          # Exclude accepted queries from the build
+          #exclude_queries: ""
 
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -33,6 +33,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Determine image version
+        id: version
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.head_ref || github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.head_ref || github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Support PR ref versions
+          [[ "${{ github.ref }}" == "refs/pull/"* ]] && VERSION=PR-$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\)/merge,\1,')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          # Use input parameter 'image-tag' if present
+          [[ "${{ github.event.inputs.image-tag }}" != '' ]] && VERSION=$(echo "${{ github.event.inputs.image-tag }}")
+          echo VERSION=$VERSION
+          echo "::set-output name=image_tag::$VERSION"
+
       # It's also possible to scan your private registry with Trivy's built-in image scan.
       # All you have to do is set ENV vars.
       # Docker Hub needs TRIVY_USERNAME and TRIVY_PASSWORD.
@@ -43,7 +59,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "ghcr.io/catenax-ng/irs-api:latest"
+          image-ref: "ghcr.io/catenax-ng/irs-api:${{ steps.version.outputs.image_tag }} "
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,7 +34,7 @@ jobs:
           format: "sarif"
           output: "trivy-results1.sarif"
           severity: "CRITICAL,HIGH"
-          skip-dirs: "charts/connector/aasregistry,charts/connector/daps,charts/connector/edc-provider,charts/connector/submodelservers,charts/irs-environments/local"
+          skip-dirs: "charts/connector/aasregistry,charts/connector/daps,charts/connector/edc-provider,charts/connector/submodelservers,charts/irs-environments/local" # skip scanning external images
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
@@ -53,20 +53,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Determine image version
-        id: version
-        run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.head_ref || github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.head_ref || github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Support PR ref versions
-          [[ "${{ github.ref }}" == "refs/pull/"* ]] && VERSION=PR-$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\)/merge,\1,')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-          echo VERSION=$VERSION
-          echo "::set-output name=image_tag::$VERSION"
-
       # It's also possible to scan your private registry with Trivy's built-in image scan.
       # All you have to do is set ENV vars.
       # Docker Hub needs TRIVY_USERNAME and TRIVY_PASSWORD.
@@ -77,7 +63,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "ghcr.io/catenax-ng/irs-api:${{ steps.version.outputs.image_tag }} "
+          image-ref: "ghcr.io/catenax-ng/irs-api:latest"
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
+    pid: "host"
+    cap_drop:
+      - NET_ADMIN
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-    pid: "host"
     cap_drop:
       - NET_ADMIN
     healthcheck:

--- a/integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestConnectionProperties.java
+++ b/integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestConnectionProperties.java
@@ -26,5 +26,5 @@ import lombok.Data;
 @Data
 public class SmokeTestConnectionProperties {
     private String baseUri;
-    private String accessToken;
+    private String accessTokenUri;
 }

--- a/integration-tests/src/test/java/org/eclipse/tractusx/irs/smoketest/ItemGraphSmokeTest.java
+++ b/integration-tests/src/test/java/org/eclipse/tractusx/irs/smoketest/ItemGraphSmokeTest.java
@@ -92,7 +92,7 @@ class ItemGraphSmokeTest {
     void setUp() {
         final String accessToken = obtainAccessToken(credentialsProperties.getAuthorizationGrantType(),
                 credentialsProperties.getClientId(), credentialsProperties.getClientSecret(),
-                connectionProperties.getAccessToken());
+                connectionProperties.getAccessTokenUri());
 
         final RequestSpecBuilder builder = new RequestSpecBuilder();
         builder.addHeader("Authorization", "Bearer " + accessToken);

--- a/integration-tests/src/test/resources/application-dev.yml
+++ b/integration-tests/src/test/resources/application-dev.yml
@@ -15,4 +15,4 @@ spring:
 
 connection:
   base-uri: https://irs.dev.demo.catena-x.net
-  access-token: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+  access-token-uri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token

--- a/integration-tests/src/test/resources/application-int.yml
+++ b/integration-tests/src/test/resources/application-int.yml
@@ -15,4 +15,4 @@ spring:
 
 connection:
   base-uri: https://irs.int.demo.catena-x.net
-  access-token: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+  access-token-uri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token

--- a/integration-tests/src/test/resources/application-local.yml
+++ b/integration-tests/src/test/resources/application-local.yml
@@ -15,4 +15,4 @@ spring:
 
 connection:
   base-uri: http://localhost:8080
-  access-token: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+  access-token-uri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token

--- a/integration-tests/src/test/resources/application-prd.yml
+++ b/integration-tests/src/test/resources/application-prd.yml
@@ -15,4 +15,4 @@ spring:
 
 connection:
   base-uri: https://irs.prd.demo.catena-x.net
-  access-token: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+  access-token-uri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token


### PR DESCRIPTION
- merge https://github.com/eclipse-tractusx/item-relationship-service/pull/8 (codeql not removed),
- fixed multiple previously excluded findings,
- there are still two Kics findings excluded: both related with default minio password used in local environment only - added comment,
- api/irs-v1.0.yaml file already skipped from scanning (pre-work for https://jira.catena-x.net/browse/TRI-1030)