### PR TITLE
feat(helm):[TRI-1027] Add support for custom ENVs in Helm

### DIFF
--- a/charts/irs/CHANGELOG.md
+++ b/charts/irs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for custom environment variables in Helm chart.
 
 ## [4.2.1]
 ### Added

--- a/charts/irs/templates/deployment.yaml
+++ b/charts/irs/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "irs.secretName" . }}
                   key: edcApiSecret
+            {{- if .Values.env }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.primary.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/irs/values.yaml
+++ b/charts/irs/values.yaml
@@ -155,6 +155,12 @@ config:
   content:
 
 
+
+env: [] # You can provide your own environment variables for the IRS here.
+#  - name: JAVA_TOOL_OPTIONS
+#  - value: -Dhttps.proxyHost=1.2.3.4
+
+
 #######################
 # Minio Configuration #
 #######################

--- a/docs/src/docs/administration/troubleshooting.adoc
+++ b/docs/src/docs/administration/troubleshooting.adoc
@@ -1,3 +1,13 @@
 = Troubleshooting
 
-Coming soon...
+== Proxy support
+
+If you are using an HTTP(S) proxy for outgoing connections, you need to configure the IRS to use it.
+
+----
+JAVA_TOOL_OPTIONS=-Dhttps.proxyHost=X.X.X.X -Dhttps.proxyPort=XXXX
+----
+
+You might need to specify both `http` and `https` options, dependending on your configuration.
+
+If your proxy is requiring authentication, you can use the `.proxyUser` and `.proxyPassword` properties in addition.


### PR DESCRIPTION
Helm users are now able to provide a list of custom environment variables to the IRS deployment. This can be used to provide proxy settings, as described in the troubleshooting section of the docs.