### PR TITLE
chore(chart):[TRI-1133] Move ingress config details to environments

### DIFF
--- a/charts/irs-environments/beta/values.yaml
+++ b/charts/irs-environments/beta/values.yaml
@@ -5,6 +5,11 @@ irs-helm:
   irsUrl: "https://irs.beta.demo.catena-x.net"
   ingress:
     enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     hosts:
       - host: "irs.beta.demo.catena-x.net"
         paths:

--- a/charts/irs-environments/dev/values.yaml
+++ b/charts/irs-environments/dev/values.yaml
@@ -5,6 +5,11 @@ irs-helm:
   irsUrl: "https://irs.dev.demo.catena-x.net"
   ingress:
     enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     hosts:
       - host: "irs.dev.demo.catena-x.net"
         paths:

--- a/charts/irs-environments/esr/values.yaml
+++ b/charts/irs-environments/esr/values.yaml
@@ -5,6 +5,11 @@ irs-helm:
   irsUrl: "https://irs-esr.dev.demo.catena-x.net"
   ingress:
     enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     hosts:
       - host: "irs-esr.dev.demo.catena-x.net"
         paths:

--- a/charts/irs-environments/ess/values.yaml
+++ b/charts/irs-environments/ess/values.yaml
@@ -5,6 +5,11 @@ irs-helm:
   irsUrl: "https://irs-ess.dev.demo.catena-x.net"
   ingress:
     enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     hosts:
       - host: "irs-ess.dev.demo.catena-x.net"
         paths:

--- a/charts/irs-environments/int/values.yaml
+++ b/charts/irs-environments/int/values.yaml
@@ -5,6 +5,11 @@ irs-helm:
   irsUrl: "https://irs.int.demo.catena-x.net"
   ingress:
     enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     hosts:
       - host: "irs.int.demo.catena-x.net"
         paths:

--- a/charts/irs-environments/pen/values.yaml
+++ b/charts/irs-environments/pen/values.yaml
@@ -5,6 +5,11 @@ irs-helm:
   irsUrl: "https://irs-pen.int.demo.catena-x.net"
   ingress:
     enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     hosts:
       - host: "irs-pen.int.demo.catena-x.net"
         paths:


### PR DESCRIPTION
Ingress will be disabled by default in the future and these settings are environment-dependent anyway. There might be other ingress controllers than nginx used on a cluster.