### PR TITLE
feat(charts):[TRI-1157] Update EDC charts to 0.3.0

### DIFF
--- a/charts/edc-consumer/CHANGELOG.md
+++ b/charts/edc-consumer/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Update EDC to 0.3.0
+- Renamed controlplane property `edc.oauth.public.key.alias` to `edc.oauth.certificate.alias`
+- Changed data-endpoint `/data` to management-endpoint `/api/v1/management`
+- Removed management endpoint from ingress
+
+## [1.0.4] - 2023-02-28
+### Changed
 - Downgrade EDC to 0.1.6
 - Renamed controlplane property `edc.oauth.endpoint.audience` to `edc.ids.endpoint.audience`
 

--- a/charts/edc-consumer/Chart.yaml
+++ b/charts/edc-consumer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/edc-consumer/Chart.yaml
+++ b/charts/edc-consumer/Chart.yaml
@@ -20,7 +20,7 @@ version: 1.0.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.6"
+appVersion: "0.3.0"
 
 dependencies:
   - name: common

--- a/charts/edc-consumer/charts/edc-controlplane/Chart.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/Chart.yaml
@@ -4,6 +4,6 @@ name: edc-controlplane
 description: EDC Control-Plane
 home: https://github.com/catenax-ng/product-edc/deployment/helm/edc-controlplane
 type: application
-appVersion: 0.1.6
-version: 0.2.0
+appVersion: 0.3.0
+version: 0.3.0
 maintainers: []

--- a/charts/edc-consumer/charts/edc-controlplane/templates/configmap.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/configmap.yaml
@@ -25,14 +25,14 @@ data:
     edc.ids.endpoint={{ .Values.edc.controlplane.url }}/api/v1/ids
     edc.ids.endpoint.audience={{ .Values.edc.controlplane.url }}/api/v1/ids/data
     edc.receiver.http.endpoint={{ tpl .Values.edc.receiver.callback.url . }}
-    edc.transfer.dataplane.sync.endpoint=http://{{ .Release.Name }}-edc-dataplane:8185/api/public
+    edc.transfer.dataplane.sync.endpoint={{ .Values.edc.dataplane.url }}/api/public
     edc.transfer.proxy.endpoint={{ .Values.edc.dataplane.url }}/api/public
     edc.transfer.proxy.token.signer.privatekey.alias={{ .Values.edc.transfer.proxy.token.signer.privatekey.alias }}
     edc.transfer.proxy.token.verifier.publickey.alias={{ .Values.edc.transfer.proxy.token.verifier.publickey.alias }}
     edc.dataplane.selector.consumer.url=http://{{ .Release.Name }}-edc-dataplane:9999/api/dataplane/control
     edc.dataplane.selector.consumer.sourcetypes=HttpData
     edc.dataplane.selector.consumer.destinationtypes=HttpProxy
-    edc.dataplane.selector.consumer.properties={ "publicApiUrl": "http://{{ .Release.Name }}-edc-dataplane:8185/api/public" }
+    edc.dataplane.selector.consumer.properties={ "publicApiUrl": "{{ .Values.edc.dataplane.url }}/api/public" }
     # Postgresql related configuration
     edc.datasource.asset.name=asset
     edc.datasource.asset.url=jdbc:postgresql://{{ .Release.Name }}-postgresql-hl:5432/edc

--- a/charts/edc-consumer/charts/edc-controlplane/templates/configmap.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/configmap.yaml
@@ -10,8 +10,8 @@ data:
   configuration.properties: |-
     web.http.default.port={{ .Values.edc.endpoints.default.port }}
     web.http.default.path={{ .Values.edc.endpoints.default.path }}
-    web.http.data.port={{ .Values.edc.endpoints.data.port }}
-    web.http.data.path={{ .Values.edc.endpoints.data.path }}
+    web.http.management.port={{ .Values.edc.endpoints.management.port }}
+    web.http.management.path={{ .Values.edc.endpoints.management.path }}
     web.http.validation.port={{ .Values.edc.endpoints.validation.port }}
     web.http.validation.path={{ .Values.edc.endpoints.validation.path }}
     web.http.control.port={{ .Values.edc.endpoints.control.port }}

--- a/charts/edc-consumer/charts/edc-controlplane/templates/deployment.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/deployment.yaml
@@ -65,20 +65,29 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.edc.endpoints.default.path }}/check/liveness
-              port: default
+              path: {{ .Values.edc.endpoints.management.path }}/check/liveness
+              port: management
+              httpHeaders:
+                - name: X-Api-Key
+                  value: {{ .Values.edc.api.auth.key | quote }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.edc.endpoints.default.path }}/check/readiness
-              port: default
+              path: {{ .Values.edc.endpoints.management.path }}/check/readiness
+              port: management
+              httpHeaders:
+                - name: X-Api-Key
+                  value: {{ .Values.edc.api.auth.key | quote }}
           {{- end }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ .Values.edc.endpoints.default.path }}/check/startup
-              port: default
+              path: {{ .Values.edc.endpoints.management.path }}/check/startup
+              port: management
+              httpHeaders:
+                - name: X-Api-Key
+                  value: {{ .Values.edc.api.auth.key | quote }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           {{- end }}

--- a/charts/edc-consumer/charts/edc-controlplane/templates/deployment.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/deployment.yaml
@@ -47,8 +47,8 @@ spec:
             - name: default
               containerPort: {{ .Values.edc.endpoints.default.port }}
               protocol: TCP
-            - name: data
-              containerPort: {{ .Values.edc.endpoints.data.port }}
+            - name: management
+              containerPort: {{ .Values.edc.endpoints.management.port }}
               protocol: TCP
             - name: validation
               containerPort: {{ .Values.edc.endpoints.validation.port }}

--- a/charts/edc-consumer/charts/edc-controlplane/templates/service.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/service.yaml
@@ -17,10 +17,10 @@ spec:
       targetPort: control
       protocol: TCP
       name: control
-    - port: {{ .Values.edc.endpoints.data.port }}
-      targetPort: data
+    - port: {{ .Values.edc.endpoints.management.port }}
+      targetPort: management
       protocol: TCP
-      name: data
+      name: management
     - port: {{ .Values.edc.endpoints.validation.port }}
       targetPort: validation
       protocol: TCP

--- a/charts/edc-consumer/charts/edc-controlplane/values.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/values.yaml
@@ -121,12 +121,12 @@ edc:
       port: "8080"
       # -- The path mapping the "default" api is going to be exposed at
       path: /api
-    ## Data management API
-    data:
-      # -- The network port, which the "data" management api is going to be exposed by the container, pod and service
+    ## Management API
+    management:
+      # -- The network port, which the management api is going to be exposed by the container, pod and service
       port: "8181"
-      # -- The path mapping the "data" management api is going to be exposed at
-      path: /data
+      # -- The path mapping the management api is going to be exposed at
+      path: /api/v1/management
     ## Validation API
     validation:
       # -- The network port, which the "validation" api is going to be exposed by the container, pod and service
@@ -244,7 +244,7 @@ configuration:
     edc.oauth.client.id=
     edc.oauth.private.key.alias=
     edc.oauth.provider.jwks.url=
-    edc.oauth.public.key.alias=
+    edc.oauth.certificate.alias=
     edc.oauth.token.url=
     
     edc.vault.hashicorp.url=

--- a/charts/edc-consumer/charts/edc-dataplane/Chart.yaml
+++ b/charts/edc-consumer/charts/edc-dataplane/Chart.yaml
@@ -5,6 +5,6 @@ description: >-
   EDC Data-Plane - The Eclipse DataSpaceConnector data layer with responsibility of transferring and receiving data streams
 home: https://github.com/catenax-ng/product-edc/deployment/helm/edc-dataplane
 type: application
-appVersion: 0.1.6
-version: 0.2.0
+appVersion: 0.3.0
+version: 0.3.0
 maintainers: []

--- a/charts/edc-consumer/charts/edc-dataplane/values.yaml
+++ b/charts/edc-consumer/charts/edc-dataplane/values.yaml
@@ -215,7 +215,7 @@ configuration:
     edc.oauth.private.key.alias=
     edc.oauth.provider.audience=
     edc.oauth.provider.jwks.url=
-    edc.oauth.public.key.alias=
+    edc.oauth.certificate.alias=
     edc.oauth.token.url=
     edc.vault.hashicorp.url=
     edc.vault.hashicorp.token=

--- a/charts/edc-consumer/values.yaml
+++ b/charts/edc-consumer/values.yaml
@@ -21,7 +21,6 @@ edc-controlplane:
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       endpoints:
         - ids
-        - data
       className: ""
       tls:
         - hosts:
@@ -59,7 +58,7 @@ edc-controlplane:
       edc.oauth.client.id=<daps-client-id>
       edc.oauth.private.key.alias=<daps-privatekey-name>
       edc.oauth.provider.jwks.url=<daps-jwks-url>
-      edc.oauth.public.key.alias=<daps-certificate-name>
+      edc.oauth.certificate.alias=<daps-certificate-name>
       edc.oauth.token.url=<daps-token-url>
       edc.vault.hashicorp.url=<vault-url>
       edc.vault.hashicorp.token=<vault-token>
@@ -100,7 +99,7 @@ edc-dataplane:
       edc.oauth.private.key.alias=<daps-privatekey-name>
       edc.oauth.provider.audience=idsc:IDS_CONNECTORS_ALL
       edc.oauth.provider.jwks.url=<daps-jwks-url>
-      edc.oauth.public.key.alias=<daps-certificate-name>
+      edc.oauth.certificate.alias=<daps-certificate-name>
       edc.oauth.token.url=<daps-token-url>
       edc.vault.hashicorp.url=<vault-url>
       edc.vault.hashicorp.token=<vault-token>


### PR DESCRIPTION
- Update EDC to 0.3.0
- Renamed controlplane property `edc.oauth.public.key.alias` to `edc.oauth.certificate.alias`
- Changed data-endpoint `/data` to management-endpoint `/api/v1/management`
- Removed management endpoint from ingress