### PR TITLE
fix(log):[TRI-827] Remove or mask log output of secret information

### DIFF
--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/edc/EdcCallbackController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/edc/EdcCallbackController.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.dataspaceconnector.spi.types.domain.edr.EndpointDataReference;
 import org.eclipse.tractusx.irs.IrsApplication;
-import org.eclipse.tractusx.irs.util.JsonUtil;
+import org.eclipse.tractusx.irs.util.Masker;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,13 +44,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class EdcCallbackController {
 
     private final EndpointDataReferenceStorage storage;
-    private final JsonUtil jsonUtil;
 
     @PostMapping("/endpoint-data-reference")
     public void receiveEdcCallback(final @RequestBody EndpointDataReference dataReference) {
-        log.debug("Received EndpointDataReference: {}", jsonUtil.asString(dataReference));
+        log.debug("Received EndpointDataReference with ID {} and endpoint {}", dataReference.getId(),
+                dataReference.getEndpoint());
         final var contractAgreementId = dataReference.getProperties().get("cid");
         storage.put(contractAgreementId, dataReference);
-        log.info("Endpoint Data Reference received and cached for agreement: {}", contractAgreementId);
+        log.info("Endpoint Data Reference received and cached for agreement: {}", Masker.mask(contractAgreementId));
     }
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/edc/EdcSubmodelClient.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/edc/EdcSubmodelClient.java
@@ -45,6 +45,7 @@ import org.eclipse.tractusx.irs.exceptions.EdcClientException;
 import org.eclipse.tractusx.irs.services.AsyncPollingService;
 import org.eclipse.tractusx.irs.services.OutboundMeterRegistryService;
 import org.eclipse.tractusx.irs.util.JsonUtil;
+import org.eclipse.tractusx.irs.util.Masker;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
@@ -171,13 +172,12 @@ class EdcSubmodelClientImpl implements EdcSubmodelClient {
 
     private Optional<String> retrieveSubmodelData(final String submodel, final String contractAgreementId,
             final StopWatch stopWatch) {
-        log.info("Retrieving dataReference from storage for contractAgreementId {}", contractAgreementId);
+        log.info("Retrieving dataReference from storage for contractAgreementId {}", Masker.mask(contractAgreementId));
         final Optional<EndpointDataReference> dataReference = endpointDataReferenceStorage.remove(contractAgreementId);
 
         if (dataReference.isPresent()) {
             final EndpointDataReference ref = dataReference.get();
-            log.info("Retrieving data from EDC data plane with dataReference {}:{}", ref.getAuthKey(),
-                    ref.getAuthCode());
+            log.info("Retrieving data from EDC data plane for dataReference with id {}", ref.getId());
             final String data = edcDataPlaneClient.getData(ref, submodel);
             stopWatch.stop();
             log.info("EDC Task '{}' took {} ms", stopWatch.getLastTaskName(), stopWatch.getLastTaskTimeMillis());
@@ -209,7 +209,9 @@ class EdcSubmodelClientImpl implements EdcSubmodelClient {
         });
     }
 
-    @SuppressWarnings({"PMD.AvoidRethrowingException", "PMD.AvoidCatchingGenericException"})
+    @SuppressWarnings({ "PMD.AvoidRethrowingException",
+                        "PMD.AvoidCatchingGenericException"
+    })
     private <T> T execute(final String endpointAddress, final CheckedSupplier<T> supplier) throws EdcClientException {
         if (!urlValidator.isValid(endpointAddress)) {
             throw new IllegalArgumentException(String.format("Malformed endpoint address '%s'", endpointAddress));
@@ -236,6 +238,7 @@ class EdcSubmodelClientImpl implements EdcSubmodelClient {
 
     /**
      * Functional interface for a supplier that may throw a checked exception.
+     *
      * @param <T> the returned type
      */
     private interface CheckedSupplier<T> {

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/Masker.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/Masker.java
@@ -20,34 +20,23 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-package org.eclipse.tractusx.irs.edc;
+package org.eclipse.tractusx.irs.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
-import java.time.Duration;
-import java.util.Map;
-
-import org.eclipse.dataspaceconnector.spi.types.domain.edr.EndpointDataReference;
-import org.junit.jupiter.api.Test;
-
-class EdcCallbackControllerTest {
-
-    private final EndpointDataReferenceStorage storage = new EndpointDataReferenceStorage(Duration.ofMinutes(1));
-    private final EdcCallbackController testee = new EdcCallbackController(storage);
-
-    @Test
-    void shouldStoreAgreementId() {
-        // arrange
-        final var ref = EndpointDataReference.Builder.newInstance()
-                                                     .endpoint("test")
-                                                     .properties(Map.of("cid", "testId"))
-                                                     .build();
-
-        // act
-        testee.receiveEdcCallback(ref);
-
-        // assert
-        final var result = storage.remove("testId");
-        assertThat(result).isNotNull().contains(ref);
+/**
+ * Utility class to mask strings for log output
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Masker {
+    public static String mask(final String stringToMask) {
+        if (StringUtils.length(stringToMask) <= 4) {
+            return "****"; // mask everything
+        }
+        // mask everything after the first 4 characters
+        final String mask = StringUtils.repeat("*", stringToMask.length() - 4);
+        return StringUtils.overlay(stringToMask, mask, 4, stringToMask.length());
     }
 }


### PR DESCRIPTION
EDC ContractAgreementID and the auth code for retrieving submodels are considered secret information and need to be protected.