### PR TITLE
chore(workflows): Stop running workflows in PRs that will fail

### DIFF
--- a/.github/workflows/irs-build.yml
+++ b/.github/workflows/irs-build.yml
@@ -48,10 +48,10 @@ jobs:
           mvn clean verify --batch-mode
 
   analyze_with_Sonar:
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     # No need to run if we cannot use the sonar token
-    if: env.SONAR_TOKEN != ''
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -81,6 +81,7 @@ jobs:
       - name: Analyze with Sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           mvn --batch-mode --update-snapshots verify \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \

--- a/.github/workflows/irs-build.yml
+++ b/.github/workflows/irs-build.yml
@@ -48,6 +48,10 @@ jobs:
           mvn clean verify --batch-mode
 
   analyze_with_Sonar:
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    # No need to run if we cannot use the sonar token
+    if: env.SONAR_TOKEN != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -77,7 +81,6 @@ jobs:
       - name: Analyze with Sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           mvn --batch-mode --update-snapshots verify \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
@@ -117,14 +120,20 @@ jobs:
       - name: Log in to registry
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
+        if: >-
+          env.DOCKER_HUB_USER == '' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          github.actor != 'dependabot[bot]'
         # This is where you will update the PAT to GITHUB_TOKEN
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image (GHCR)
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
+        if: >- 
+          env.DOCKER_HUB_USER == '' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          github.actor != 'dependabot[bot]'
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           # Change all uppercase to lowercase
@@ -170,6 +179,9 @@ jobs:
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
 
   trigger-trivy-image-scan:
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]'
     needs:
       - build_images
     uses: ./.github/workflows/trivy-image-scan.yml

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -28,11 +28,10 @@ on:
 
 jobs:
   build:
-    env:
-      JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-      JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
     # This job does not need to run unless we can access the credentials
-    if: JIRA_USERNAME != ''
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -53,6 +52,9 @@ jobs:
 
       - name: Download Feature Files
         id: download
+        env:
+          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
+          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
         # JIRA filter 11349: project = TRI AND type = Test AND "Test Type" = Cucumber
         # Downloads all feature files of cucumber tests inside TRI project
         run: |

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -3,12 +3,14 @@ name: IRS Cucumber Xray execution
 on:
   workflow_dispatch: # Trigger manually
   push:
-    branches: main
+    branches:
+      - main
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
   pull_request:
-    branches: main
+    branches:
+      - main
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
@@ -26,6 +28,11 @@ on:
 
 jobs:
   build:
+    env:
+      JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
+      JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
+    # This job does not need to run unless we can access the credentials
+    if: JIRA_USERNAME != ''
     runs-on: ubuntu-latest
 
     steps:
@@ -46,11 +53,8 @@ jobs:
 
       - name: Download Feature Files
         id: download
-        env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
-          # JIRA filter 11349: project = TRI AND type = Test AND "Test Type" = Cucumber
-          # Downloads all feature files of cucumber tests inside TRI project
+        # JIRA filter 11349: project = TRI AND type = Test AND "Test Type" = Cucumber
+        # Downloads all feature files of cucumber tests inside TRI project
         run: |
           export HTTP_RESULT=$(curl -s --show-error -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)
           [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]


### PR DESCRIPTION
Since secrets cannot be accessed in external PRs, we don't need to run workflows that need them - they will fail all the time. So let's keep these checks helpful and green, if we can.