### PR TITLE
Fix/tri 1223 create secrets

### DIFF
--- a/charts/edc-consumer/CHANGELOG.md
+++ b/charts/edc-consumer/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Moved vault token and api key to secret for control- and data-plane.
+- Moved vault token configuration from `configuration.properties` to `edc.vault.hashicorp.token`
 
 ## [1.1.2] - 2023-03-30
 ### Added

--- a/charts/edc-consumer/charts/edc-controlplane/templates/configmap.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/configmap.yaml
@@ -18,7 +18,6 @@ data:
     web.http.control.path={{ .Values.edc.endpoints.control.path }}
     web.http.protocol.port={{ .Values.edc.endpoints.protocol.port }}
     web.http.protocol.path={{ .Values.edc.endpoints.protocol.path }}
-    edc.api.auth.key={{ .Values.edc.api.auth.key }}
     ids.webhook.address={{ .Values.edc.controlplane.url }}
     edc.ids.id=urn:connector:edc-consumer-controlplane
     edc.ids.catalog.id=urn:catalog:default

--- a/charts/edc-consumer/charts/edc-controlplane/templates/deployment.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/deployment.yaml
@@ -91,12 +91,23 @@ spec:
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           {{- end }}
+          env:
+            - name: EDC_API_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "edc-controlplane.fullname" . }}
+                  key: apiToken
+            - name: EDC_VAULT_HASHICORP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "edc-controlplane.fullname" . }}
+                  key: vaultToken
           envFrom:
             - configMapRef:
                 name: {{ include "edc-controlplane.fullname" . }}-env
             {{- if .Values.envSecretName }}
             - secretRef:
-              name: {{ .Values.envSecretName | quote }}
+                name: {{ .Values.envSecretName | quote }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/edc-consumer/charts/edc-controlplane/templates/secrets.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "edc-controlplane.fullname" . }}
+  namespace: {{ .Release.Namespace | default "default" | quote }}
+  labels:
+    {{- include "edc-controlplane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  vaultToken: {{ .Values.edc.vault.hashicorp.token | default "minio" | b64enc | quote }}
+  apiToken: {{ .Values.edc.api.auth.key | default "" | b64enc | quote }}

--- a/charts/edc-consumer/charts/edc-controlplane/values.yaml
+++ b/charts/edc-consumer/charts/edc-controlplane/values.yaml
@@ -114,6 +114,9 @@ edc:
     url:
   dataplane:
     url:
+  vault:
+    hashicorp:
+      token:
   endpoints:
     ## Default api exposing health checks etc
     default:
@@ -248,7 +251,6 @@ configuration:
     edc.oauth.token.url=
     
     edc.vault.hashicorp.url=
-    edc.vault.hashicorp.token=
     edc.vault.hashicorp.api.secret.path=
     
     edc.data.encryption.keys.alias=

--- a/charts/edc-consumer/charts/edc-dataplane/templates/configmap.yaml
+++ b/charts/edc-consumer/charts/edc-dataplane/templates/configmap.yaml
@@ -14,7 +14,6 @@ data:
     web.http.public.path={{ .Values.edc.endpoints.public.path }}
     web.http.control.port={{ .Values.edc.endpoints.control.port }}
     web.http.control.path={{ .Values.edc.endpoints.control.path }}
-    edc.api.auth.key={{ .Values.edc.api.auth.key }}
     edc.dataplane.token.validation.endpoint=http://{{ .Release.Name }}-edc-controlplane:8182/validation/token
     edc.vault.hashicorp.timeout.seconds=30
     edc.vault.hashicorp.health.check.enabled=true

--- a/charts/edc-consumer/charts/edc-dataplane/templates/deployment.yaml
+++ b/charts/edc-consumer/charts/edc-dataplane/templates/deployment.yaml
@@ -76,12 +76,23 @@ spec:
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           {{- end }}
+          env:
+            - name: EDC_API_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "edc-dataplane.fullname" . }}
+                  key: apiToken
+            - name: EDC_VAULT_HASHICORP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "edc-dataplane.fullname" . }}
+                  key: vaultToken
           envFrom:
             - configMapRef:
                 name: {{ include "edc-dataplane.fullname" . }}-env
             {{- if .Values.envSecretName }}
             - secretRef:
-            name: {{ .Values.envSecretName | quote }}
+                name: {{ .Values.envSecretName | quote }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/edc-consumer/charts/edc-dataplane/templates/secrets.yaml
+++ b/charts/edc-consumer/charts/edc-dataplane/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "edc-dataplane.fullname" . }}
+  namespace: {{ .Release.Namespace | default "default" | quote }}
+  labels:
+    {{- include "edc-dataplane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  vaultToken: {{ .Values.edc.vault.hashicorp.token | default "minio" | b64enc | quote }}
+  apiToken: {{ .Values.edc.api.auth.key | default "" | b64enc | quote }}

--- a/charts/edc-consumer/charts/edc-dataplane/values.yaml
+++ b/charts/edc-consumer/charts/edc-dataplane/values.yaml
@@ -121,6 +121,9 @@ edc:
   api:
     auth:
       key:
+  vault:
+    hashicorp:
+      token:
 service:
   # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
   type: ClusterIP
@@ -218,5 +221,4 @@ configuration:
     edc.oauth.certificate.alias=
     edc.oauth.token.url=
     edc.vault.hashicorp.url=
-    edc.vault.hashicorp.token=
     edc.vault.hashicorp.api.secret.path=

--- a/charts/edc-consumer/values.yaml
+++ b/charts/edc-consumer/values.yaml
@@ -53,6 +53,9 @@ edc-controlplane:
       url: "https://<controlplane-url>"
     dataplane:
       url: "https://<dataplane-url>"
+    vault:
+      hashicorp:
+        token: "<vault-token>"
   configuration:
     properties: |-
       edc.oauth.client.id=<daps-client-id>
@@ -61,7 +64,6 @@ edc-controlplane:
       edc.oauth.certificate.alias=<daps-certificate-name>
       edc.oauth.token.url=<daps-token-url>
       edc.vault.hashicorp.url=<vault-url>
-      edc.vault.hashicorp.token=<vault-token>
       edc.vault.hashicorp.api.secret.path=<vault-secret-store-path>
       edc.data.encryption.keys.alias=<daps-privatekey-name>
       edc.data.encryption.algorithm=NONE
@@ -74,6 +76,9 @@ edc-dataplane:
     api:
       auth:
         key: "<edc-api-key>"
+    vault:
+      hashicorp:
+        token: "<vault-token>"
   ## Ingress declaration to expose the network service.
   ingresses:
     - enabled: true
@@ -102,5 +107,4 @@ edc-dataplane:
       edc.oauth.certificate.alias=<daps-certificate-name>
       edc.oauth.token.url=<daps-token-url>
       edc.vault.hashicorp.url=<vault-url>
-      edc.vault.hashicorp.token=<vault-token>
       edc.vault.hashicorp.api.secret.path=<vault-secret-store-path>


### PR DESCRIPTION
- Moved vault token and api key to secret for control- and data-plane.
- Moved vault token configuration from `configuration.properties` to `edc.vault.hashicorp.token`