### PR TITLE
chore(charts): Increase EDC provider PVC size to 2Gi

### DIFF
--- a/charts/connector/edc-provider/values-dev-1.yaml
+++ b/charts/connector/edc-provider/values-dev-1.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1.5
           memory: 1.5Gi
+      extendedConfiguration:
+        "idle_in_transaction_session_timeout=300s"
       persistence:
         size: 2Gi
 

--- a/charts/connector/edc-provider/values-dev-1.yaml
+++ b/charts/connector/edc-provider/values-dev-1.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1.5
           memory: 1.5Gi
+      persistence:
+        size: 2Gi
 
   ##################################
   # EDC Controlplane Configuration #

--- a/charts/connector/edc-provider/values-dev-2.yaml
+++ b/charts/connector/edc-provider/values-dev-2.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1.5
           memory: 1.5Gi
+      extendedConfiguration:
+        idle_in_transaction_session_timeout: 300s
       persistence:
         size: 2Gi
 

--- a/charts/connector/edc-provider/values-dev-2.yaml
+++ b/charts/connector/edc-provider/values-dev-2.yaml
@@ -12,7 +12,7 @@ irs-edc-provider:
           cpu: 1.5
           memory: 1.5Gi
       extendedConfiguration:
-        idle_in_transaction_session_timeout: 300s
+        "idle_in_transaction_session_timeout=300s"
       persistence:
         size: 2Gi
 

--- a/charts/connector/edc-provider/values-dev-2.yaml
+++ b/charts/connector/edc-provider/values-dev-2.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1.5
           memory: 1.5Gi
+      persistence:
+        size: 2Gi
 
   ##################################
   # EDC Controlplane Configuration #

--- a/charts/connector/edc-provider/values-dev-3.yaml
+++ b/charts/connector/edc-provider/values-dev-3.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1.5
           memory: 1.5Gi
+      extendedConfiguration:
+        "idle_in_transaction_session_timeout=300s"
       persistence:
         size: 2Gi
 

--- a/charts/connector/edc-provider/values-dev-3.yaml
+++ b/charts/connector/edc-provider/values-dev-3.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1.5
           memory: 1.5Gi
+      persistence:
+        size: 2Gi
 
   ##################################
   # EDC Controlplane Configuration #

--- a/charts/connector/edc-provider/values-ess.yaml
+++ b/charts/connector/edc-provider/values-ess.yaml
@@ -11,6 +11,8 @@ irs-edc-provider:
         limits:
           cpu: 1
           memory: 1.5Gi
+      persistence:
+        size: 2Gi
 
   ##################################
   # EDC Controlplane Configuration #


### PR DESCRIPTION
Increased PVC size to 2Gi as a workaround for the database getting filled too fast