### PR TITLE
chore(release):[TRI-708] Fix release workflows

### DIFF
--- a/.github/workflows/jira-publish-release.yaml
+++ b/.github/workflows/jira-publish-release.yaml
@@ -43,20 +43,20 @@ jobs:
           VERSION_ID: ${{ env.versionId }}
           RELEASE_DATE: ${{ env.NOW }}
         run: |
-          curl --request PUT --url 'https://jira.catena-x.net/rest/api/latest/version/$VERSION_ID' \
+          curl --request PUT --url "https://jira.catena-x.net/rest/api/latest/version/$VERSION_ID" \
           --user $JIRA_USERNAME:$JIRA_PASSWORD \
           --header 'Accept: application/json' \
           --header 'Content-Type: application/json' \
-          --data '{
-            "archived": false,
-            "description": $VERSION,
-            "id": $VERSION_ID,
-            "name": $VERSION,
-            "releaseDate": $RELEASE_DATE,
-            "released": true,
-            "overdue": false,
-            "projectId": 10211
-          }'
+          --data "{
+            \"archived\": false,
+            \"description\": \"$VERSION\",
+            \"id\": $VERSION_ID,
+            \"name\": \"$VERSION\",
+            \"releaseDate\": \"$RELEASE_DATE\",
+            \"released\": true,
+            \"overdue\": false,
+            \"projectId\": 10211
+          }"
 
       - name: Create NEXT_RELEASE Version in Jira
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,3 +52,4 @@ jobs:
     uses: ./.github/workflows/jira-publish-release.yaml
     with:
       version: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
Secrets are now inherited when calling the Jira release workflow. The Jira release workflow now correctly builds the body when renaming and releasing the version.