### PR TITLE
Chore/dependency check

### DIFF
--- a/.config/owasp-suppressions.xml
+++ b/.config/owasp-suppressions.xml
@@ -21,4 +21,11 @@
         <gav regex="true">com\.google\.guava:guava.*</gav>
         <vulnerabilityName>CVE-2023-2976</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Vulnerability is a false positive.
+        ]]></notes>
+        <gav regex="true">com\.fasterxml\.jackson\.core:jackson-databind.*</gav>
+        <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/.config/owasp-suppressions.xml
+++ b/.config/owasp-suppressions.xml
@@ -25,7 +25,7 @@
         <notes><![CDATA[
         Vulnerability is a false positive.
         ]]></notes>
-        <gav regex="true">com\.fasterxml\.jackson\.core:jackson-databind.*</gav>
+        <gav regex="true">com\.fasterxml\.jackson\.core:jackson\-databind.*</gav>
         <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: run maven owasp plugin
-        run: mvn --batch-mode install -Pdependency-check -DskipTests
+        run: mvn --batch-mode clean package dependency-check:aggregate -Pdependency-check -DskipTest
 
       - name: upload results
         if: always()

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: run maven owasp plugin
-        run: mvn --batch-mode clean package dependency-check:aggregate -Pdependency-check -DskipTest
+        run: mvn --batch-mode clean package dependency-check:aggregate -Pdependency-check -DskipTests
 
       - name: upload results
         if: always()


### PR DESCRIPTION
Suppressing CVE-2023-35116 for jackson-databind. This is not a vulerability as can be read here:
https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1608884814
I noticed that dependency check stops after finding the first vulnerable dependency, so I changed it to `dependency-check:aggregate`