### PR TITLE
chore(trg):[TRI-1456] Add workflow for k8s compatibility testing

### DIFF
--- a/.github/workflows/helm-test-backwards-compatability.yaml
+++ b/.github/workflows/helm-test-backwards-compatability.yaml
@@ -1,0 +1,36 @@
+name: Test k8s version compatability
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_image_latest:
+        description: 'First version of kindest/node image for k8s kind cluster'
+        default: 'kindest/node:v1.27.3'
+        required: false
+        type: string
+      node_image_second_latest:
+        description: 'Second version of kindest/node image for k8s kind cluster'
+        default: 'kindest/node:v1.26.6'
+        required: false
+        type: string
+      node_image_third_latest:
+        description: 'Third version of kindest/node image for k8s kind cluster'
+        default: 'kindest/node:v1.25.11'
+        required: false
+        type: string
+
+jobs:
+  test-latest:
+    uses: ./.github/workflows/helm-test.yaml
+    with:
+      node_image: ${{ github.event.inputs.node_image_latest || 'kindest/node:v1.27.3' }}
+
+  test-second-latest:
+    uses: ./.github/workflows/helm-test.yaml
+    with:
+      node_image: ${{ github.event.inputs.node_image_second_latest || 'kindest/node:v1.26.6' }}
+
+  test-third-latest:
+    uses: ./.github/workflows/helm-test.yaml
+    with:
+      node_image: ${{ github.event.inputs.node_image_third_latest || 'kindest/node:v1.25.11' }}

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -5,6 +5,19 @@ on:
     paths:
       - 'charts/**'
   workflow_dispatch:
+    inputs:
+      node_image:
+        description: 'kindest/node image for k8s kind cluster'
+        default: 'kindest/node:v1.27.3'
+        required: false
+        type: string
+  workflow_call: # Trigger by another workflow
+    inputs:
+      node_image:
+        description: 'kindest/node image for k8s kind cluster'
+        default: 'kindest/node:v1.27.3'
+        required: false
+        type: string
 
 jobs:
   lint-test:
@@ -17,6 +30,8 @@ jobs:
 
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
+        with:
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
       - name: Build image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This will run the Helm test workflow for the latest three k8s versions and check the compatibility in compliance with https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-10/.