### PR TITLE
feat(library):[TRI-1409] Update KinD version to 0.20.0

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
+          version: v0.20.0
 
       - name: Build image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
We need to use the latest KinD version to support newer kubernetes image versions (1.25+)