### PR TITLE
feat(registryclient):[TRI-1470] Improve registry client library

### DIFF
--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackController.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackController.java
@@ -53,7 +53,7 @@ public class EdcCallbackController {
                 dataReference.getEndpoint());
         final String authCode = dataReference.getAuthCode();
         if (authCode != null) {
-            final var contractAgreementId = EDRAuthCode.extractContractAgreementId(authCode).getCid();
+            final var contractAgreementId = EDRAuthCode.fromAuthCodeToken(authCode).getCid();
             storage.put(contractAgreementId, dataReference);
             log.info("Endpoint Data Reference received and cached for agreement: {}", Masker.mask(contractAgreementId));
         } else {

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackController.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackController.java
@@ -22,9 +22,6 @@
  ********************************************************************************/
 package org.eclipse.tractusx.irs.edc.client;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +53,7 @@ public class EdcCallbackController {
                 dataReference.getEndpoint());
         final String authCode = dataReference.getAuthCode();
         if (authCode != null) {
-            final var contractAgreementId = extractContractAgreementId(authCode);
+            final var contractAgreementId = EDRAuthCode.extractContractAgreementId(authCode).getCid();
             storage.put(contractAgreementId, dataReference);
             log.info("Endpoint Data Reference received and cached for agreement: {}", Masker.mask(contractAgreementId));
         } else {
@@ -65,11 +62,4 @@ public class EdcCallbackController {
         }
     }
 
-    private String extractContractAgreementId(final String token) {
-        final var chunks = token.split("\\.");
-        final var decoder = Base64.getUrlDecoder();
-        final var payload = new String(decoder.decode(chunks[1]), StandardCharsets.UTF_8);
-        final var authCode = StringMapper.mapFromString(payload, EDRAuthCode.class);
-        return authCode.getCid();
-    }
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/EDRAuthCode.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/EDRAuthCode.java
@@ -22,9 +22,13 @@
  ********************************************************************************/
 package org.eclipse.tractusx.irs.edc.client.model;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
+import org.eclipse.tractusx.irs.data.StringMapper;
 
 /**
  * The decoded Auth code JWT.
@@ -36,4 +40,11 @@ public class EDRAuthCode {
     private final long exp;
     private final String dad;
     private final String cid;
+
+    public static EDRAuthCode extractContractAgreementId(final String token) {
+        final var chunks = token.split("\\.");
+        final var decoder = Base64.getUrlDecoder();
+        final var payload = new String(decoder.decode(chunks[1]), StandardCharsets.UTF_8);
+        return StringMapper.mapFromString(payload, EDRAuthCode.class);
+    }
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/EDRAuthCode.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/EDRAuthCode.java
@@ -41,7 +41,7 @@ public class EDRAuthCode {
     private final String dad;
     private final String cid;
 
-    public static EDRAuthCode extractContractAgreementId(final String token) {
+    public static EDRAuthCode fromAuthCodeToken(final String token) {
         final var chunks = token.split("\\.");
         final var decoder = Base64.getUrlDecoder();
         final var payload = new String(decoder.decode(chunks[1]), StandardCharsets.UTF_8);

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryKey.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryKey.java
@@ -24,8 +24,8 @@ package org.eclipse.tractusx.irs.registryclient;
 
 /**
  * Key object contains required attributes for identify part chain entry node
- * @param globalAssetId Id of global asset
- * @param bpn bpn of entity
+ * @param shellId ID of an asset administration shell (note: this is NOT a globalAssetId)
+ * @param bpn the business partner number which owns the asset
  */
-public record DigitalTwinRegistryKey(String globalAssetId, String bpn) {
+public record DigitalTwinRegistryKey(String shellId, String bpn) {
 }

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryService.java
@@ -33,12 +33,36 @@ import org.eclipse.tractusx.irs.registryclient.exceptions.RegistryServiceExcepti
 public interface DigitalTwinRegistryService {
 
     /**
+     * Retrieves the global asset IDs of all asset administration shells for a given BPN.
+     *
+     * @param bpn the BPN to retrieve the shells for
+     * @return the collection of global asset IDs
+     */
+    default Collection<String> lookupGlobalAssetIds(final String bpn) throws RegistryServiceException {
+        return fetchShells(lookupShellIdentifiers(bpn)).stream()
+                                                       .map(AssetAdministrationShellDescriptor::getGlobalAssetId)
+                                                       .toList();
+    }
+
+    /**
+     * Retrieves all registered shell identifiers for a given BPN.
+     *
+     * @param bpn the BPN to retrieve the shells for
+     * @return the collection of shell identifiers
+     * @deprecated replaced by {@link DigitalTwinRegistryService#lookupShellIdentifiers(String)}
+     */
+    @Deprecated(since = "1.0.0", forRemoval = true)
+    default Collection<DigitalTwinRegistryKey> lookupShells(final String bpn) throws RegistryServiceException {
+        return lookupShellIdentifiers(bpn);
+    }
+
+    /**
      * Retrieves all registered shell identifiers for a given BPN.
      *
      * @param bpn the BPN to retrieve the shells for
      * @return the collection of shell identifiers
      */
-    Collection<DigitalTwinRegistryKey> lookupShells(String bpn) throws RegistryServiceException;
+    Collection<DigitalTwinRegistryKey> lookupShellIdentifiers(String bpn) throws RegistryServiceException;
 
     /**
      * Retrieves the shell details for the given identifiers.

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/CentralDigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/CentralDigitalTwinRegistryService.java
@@ -32,7 +32,6 @@ import org.eclipse.tractusx.irs.component.assetadministrationshell.AssetAdminist
 import org.eclipse.tractusx.irs.component.assetadministrationshell.IdentifierKeyValuePair;
 import org.eclipse.tractusx.irs.registryclient.DigitalTwinRegistryKey;
 import org.eclipse.tractusx.irs.registryclient.DigitalTwinRegistryService;
-import org.eclipse.tractusx.irs.registryclient.exceptions.RegistryServiceException;
 
 /**
  * Central implementation of DigitalTwinRegistryService
@@ -46,16 +45,15 @@ public class CentralDigitalTwinRegistryService implements DigitalTwinRegistrySer
     @Override
     public Collection<AssetAdministrationShellDescriptor> fetchShells(final Collection<DigitalTwinRegistryKey> keys) {
         return keys.stream().map(key -> {
-            final String aaShellIdentification = getAAShellIdentificationOrGlobalAssetId(key.globalAssetId());
-            log.info("Retrieved AAS Identification {} for globalAssetId {}", aaShellIdentification,
-                    key.globalAssetId());
+            final String aaShellIdentification = getAAShellIdentificationOrGlobalAssetId(key.shellId());
+            log.info("Retrieved AAS Identification {} for globalAssetId {}", aaShellIdentification, key.shellId());
 
             return digitalTwinRegistryClient.getAssetAdministrationShellDescriptor(aaShellIdentification);
         }).toList();
     }
 
     @Override
-    public Collection<DigitalTwinRegistryKey> lookupShells(final String bpn) throws RegistryServiceException {
+    public Collection<DigitalTwinRegistryKey> lookupShellIdentifiers(final String bpn) {
         log.info("Looking up shells for bpn {}", bpn);
         final var shellIds = digitalTwinRegistryClient.getAllAssetAdministrationShellIdsByAssetLink(List.of());
         log.info("Found {} shells in total", shellIds.size());
@@ -64,9 +62,9 @@ public class CentralDigitalTwinRegistryService implements DigitalTwinRegistrySer
 
     private String getAAShellIdentificationOrGlobalAssetId(final String globalAssetId) {
         final IdentifierKeyValuePair identifierKeyValuePair = IdentifierKeyValuePair.builder()
-                                                                           .name("globalAssetId")
-                                                                           .value(globalAssetId)
-                                                                           .build();
+                                                                                    .name("globalAssetId")
+                                                                                    .value(globalAssetId)
+                                                                                    .build();
 
         final List<String> allAssetAdministrationShellIdsByAssetLink = digitalTwinRegistryClient.getAllAssetAdministrationShellIdsByAssetLink(
                 Collections.singletonList(identifierKeyValuePair));

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryService.java
@@ -109,7 +109,7 @@ public class DecentralDigitalTwinRegistryService implements DigitalTwinRegistryS
     }
 
     private Instant extractTokenExpiration(final String token) {
-        return Instant.ofEpochSecond(EDRAuthCode.extractContractAgreementId(token).getExp());
+        return Instant.ofEpochSecond(EDRAuthCode.fromAuthCodeToken(token).getExp());
     }
 
     private AssetAdministrationShellDescriptor fetchShellDescriptor(final EndpointDataReference endpointDataReference,

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryService.java
@@ -22,16 +22,22 @@
  ********************************************************************************/
 package org.eclipse.tractusx.irs.registryclient.decentral;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.eclipse.tractusx.irs.component.assetadministrationshell.AssetAdministrationShellDescriptor;
 import org.eclipse.tractusx.irs.component.assetadministrationshell.IdentifierKeyValuePair;
+import org.eclipse.tractusx.irs.edc.client.model.EDRAuthCode;
 import org.eclipse.tractusx.irs.registryclient.DigitalTwinRegistryKey;
 import org.eclipse.tractusx.irs.registryclient.DigitalTwinRegistryService;
 import org.eclipse.tractusx.irs.registryclient.discovery.ConnectorEndpointsService;
@@ -53,34 +59,89 @@ public class DecentralDigitalTwinRegistryService implements DigitalTwinRegistryS
     @Override
     public Collection<AssetAdministrationShellDescriptor> fetchShells(final Collection<DigitalTwinRegistryKey> keys)
             throws RegistryServiceException {
-        final Set<String> calledEndpoints = new HashSet<>();
-
-        final var shells = keys.stream().map(key -> {
-            log.info("Retrieved AAS Identification for DigitalTwinRegistryKey: {}", key);
-            final List<String> connectorEndpoints = connectorEndpointsService.fetchConnectorEndpoints(key.bpn());
-            calledEndpoints.addAll(connectorEndpoints);
-            final EndpointDataReference endpointDataReference = getEndpointDataReference(connectorEndpoints);
-            final IdentifierKeyValuePair identifierKeyValuePair = IdentifierKeyValuePair.builder()
-                                                                                        .name("globalAssetId")
-                                                                                        .value(key.globalAssetId())
-                                                                                        .build();
-            final String aaShellIdentification = decentralDigitalTwinRegistryClient.getAllAssetAdministrationShellIdsByAssetLink(
-                                                                                           endpointDataReference, List.of(identifierKeyValuePair))
-                                                                                   .stream()
-                                                                                   .findFirst()
-                                                                                   .orElse(key.globalAssetId());
-            log.info("Retrieved AAS Identification {} for globalAssetId {}", aaShellIdentification,
-                    key.globalAssetId());
-
-            return decentralDigitalTwinRegistryClient.getAssetAdministrationShellDescriptor(endpointDataReference,
-                    aaShellIdentification);
-        }).toList();
-
-        if (shells.isEmpty()) {
+        log.info("Fetching shell(s) for {} key(s)", keys.size());
+        final var calledEndpoints = new HashSet<String>();
+        final var collectedShells = groupKeysByBpn(keys).flatMap(
+                entry -> fetchShellDescriptors(calledEndpoints, entry.getKey(), entry.getValue())).toList();
+        if (collectedShells.isEmpty()) {
             throw new ShellNotFoundException("Unable to find any of the requested shells", calledEndpoints);
         } else {
-            return shells;
+            log.info("Found {} shell(s) for {} key(s)", collectedShells.size(), keys.size());
+            return collectedShells;
         }
+    }
+
+    private static Stream<Map.Entry<String, List<DigitalTwinRegistryKey>>> groupKeysByBpn(
+            final Collection<DigitalTwinRegistryKey> keys) {
+        return keys.stream().collect(Collectors.groupingBy(DigitalTwinRegistryKey::bpn)).entrySet().stream();
+    }
+
+    @NotNull
+    private Stream<AssetAdministrationShellDescriptor> fetchShellDescriptors(final Set<String> calledEndpoints,
+            final String bpn, final List<DigitalTwinRegistryKey> keys) {
+        log.info("Fetching {} shells for bpn {}", keys.size(), bpn);
+        final var connectorEndpoints = connectorEndpointsService.fetchConnectorEndpoints(bpn);
+        calledEndpoints.addAll(connectorEndpoints);
+
+        final List<AssetAdministrationShellDescriptor> descriptors = new ArrayList<>();
+
+        EndpointDataReference endpointDataReference = null;
+        for (final DigitalTwinRegistryKey key : keys) {
+            endpointDataReference = renewIfNecessary(endpointDataReference, connectorEndpoints);
+            descriptors.add(fetchShellDescriptor(endpointDataReference, key));
+        }
+
+        return descriptors.stream();
+    }
+
+    private EndpointDataReference renewIfNecessary(final EndpointDataReference endpointDataReference,
+            final List<String> connectorEndpoints) {
+        if (endpointDataReference == null || endpointDataReference.getAuthCode() == null) {
+            return getEndpointDataReference(connectorEndpoints);
+        } else {
+            final var tokenExpirationInstant = extractTokenExpiration(endpointDataReference.getAuthCode());
+            if (Instant.now().isAfter(tokenExpirationInstant)) {
+                log.info("EndpointDataReference token has expired, getting a new one.");
+                return getEndpointDataReference(connectorEndpoints);
+            }
+            return endpointDataReference;
+        }
+    }
+
+    private Instant extractTokenExpiration(final String token) {
+        return Instant.ofEpochSecond(EDRAuthCode.extractContractAgreementId(token).getExp());
+    }
+
+    private AssetAdministrationShellDescriptor fetchShellDescriptor(final EndpointDataReference endpointDataReference,
+            final DigitalTwinRegistryKey key) {
+        log.info("Retrieving AAS Identification for DigitalTwinRegistryKey: {}", key);
+        final String aaShellIdentification = mapToShellId(endpointDataReference, key.shellId());
+
+        return decentralDigitalTwinRegistryClient.getAssetAdministrationShellDescriptor(endpointDataReference,
+                aaShellIdentification);
+    }
+
+    /**
+     * This method takes the provided ID and maps it to the corresponding asset administration shell ID.
+     * If the ID is already a shellId, the same ID will be returned.
+     * If the ID is a globalAssetId, the corresponding shellId will be returned.
+     *
+     * @param endpointDataReference the reference to access the digital twin registry
+     * @param key                   the ambiguous key (shellId or globalAssetId)
+     * @return the shellId
+     */
+    @NotNull
+    private String mapToShellId(final EndpointDataReference endpointDataReference, final String key) {
+        final var identifierKeyValuePair = IdentifierKeyValuePair.builder().name("globalAssetId").value(key).build();
+        final var aaShellIdentification = decentralDigitalTwinRegistryClient.getAllAssetAdministrationShellIdsByAssetLink(
+                endpointDataReference, List.of(identifierKeyValuePair)).stream().findFirst().orElse(key);
+
+        if (key.equals(aaShellIdentification)) {
+            log.info("Found shell with shellId {} in registry", aaShellIdentification);
+        } else {
+            log.info("Retrieved shellId {} for globalAssetId {}", aaShellIdentification, key);
+        }
+        return aaShellIdentification;
     }
 
     @NotNull
@@ -88,16 +149,21 @@ public class DecentralDigitalTwinRegistryService implements DigitalTwinRegistryS
         return endpointDataForConnectorsService.findEndpointDataForConnectors(connectorEndpoints);
     }
 
-    @Override
-    public Collection<DigitalTwinRegistryKey> lookupShells(final String bpn) throws RegistryServiceException {
-        log.info("Looking up shells for bpn {}", bpn);
+    private Collection<String> lookupShellIds(final String bpn) {
+        log.info("Looking up shell ids for bpn {}", bpn);
         final var connectorEndpoints = connectorEndpointsService.fetchConnectorEndpoints(bpn);
         final var endpointDataReference = getEndpointDataReference(connectorEndpoints);
+
         final var shellIds = decentralDigitalTwinRegistryClient.getAllAssetAdministrationShellIdsByAssetLink(
                 endpointDataReference,
                 List.of(IdentifierKeyValuePair.builder().name("manufacturerId").value(bpn).build()));
-        log.info("Found {} shells in total", shellIds.size());
-        return shellIds.stream().map(id -> new DigitalTwinRegistryKey(id, bpn)).toList();
+        log.info("Found {} shell id(s) in total", shellIds.size());
+        return shellIds;
+    }
+
+    @Override
+    public Collection<DigitalTwinRegistryKey> lookupShellIdentifiers(final String bpn) {
+        return lookupShellIds(bpn).stream().map(id -> new DigitalTwinRegistryKey(id, bpn)).toList();
     }
 
 }


### PR DESCRIPTION
Added new method to retrieve globalAssetIds for a BPN directly. This just uses the existing methods.

Refactored the existing code to be more comprehensible and added some log output. The EndpointDataReference is now renewed on demand if the token expires during the runtime. Renamed DigitalTwinRegistryService#lookupShells to lookupShellIdentifiers to be more precise. The old method points to the new one and is marked as deprecated now.