### PR TITLE
feat(irs-registry-client-irs-api):[#202] removed auto-detect bean from DigitalTwinRegistryClientLocalStub in registry-client and moved bean creation to irs-api

### DIFF
--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
@@ -49,8 +49,11 @@ import org.eclipse.tractusx.irs.common.persistence.MinioBlobPersistence;
 import org.eclipse.tractusx.irs.connector.job.JobOrchestrator;
 import org.eclipse.tractusx.irs.connector.job.JobStore;
 import org.eclipse.tractusx.irs.connector.job.JobTTL;
+import org.eclipse.tractusx.irs.data.CxTestDataContainer;
 import org.eclipse.tractusx.irs.edc.client.EdcSubmodelFacade;
 import org.eclipse.tractusx.irs.registryclient.DigitalTwinRegistryService;
+import org.eclipse.tractusx.irs.registryclient.central.DigitalTwinRegistryClient;
+import org.eclipse.tractusx.irs.registryclient.central.DigitalTwinRegistryClientLocalStub;
 import org.eclipse.tractusx.irs.registryclient.discovery.ConnectorEndpointsService;
 import org.eclipse.tractusx.irs.semanticshub.SemanticsHubFacade;
 import org.eclipse.tractusx.irs.services.MeterRegistryService;
@@ -151,4 +154,11 @@ public class JobConfiguration {
                 connectorEndpointsService);
     }
 
+    @Profile({ "local",
+               "stubtest"
+    })
+    @Bean
+    public DigitalTwinRegistryClient digitalTwinRegistryClient(final CxTestDataContainer cxTestDataContainer) {
+        return new DigitalTwinRegistryClientLocalStub(cxTestDataContainer);
+    }
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
@@ -50,7 +50,16 @@ import org.eclipse.tractusx.irs.connector.job.JobOrchestrator;
 import org.eclipse.tractusx.irs.connector.job.JobStore;
 import org.eclipse.tractusx.irs.connector.job.JobTTL;
 import org.eclipse.tractusx.irs.data.CxTestDataContainer;
+import org.eclipse.tractusx.irs.edc.client.AsyncPollingService;
+import org.eclipse.tractusx.irs.edc.client.ContractNegotiationService;
+import org.eclipse.tractusx.irs.edc.client.EDCCatalogFacade;
+import org.eclipse.tractusx.irs.edc.client.EdcConfiguration;
+import org.eclipse.tractusx.irs.edc.client.EdcDataPlaneClient;
 import org.eclipse.tractusx.irs.edc.client.EdcSubmodelFacade;
+import org.eclipse.tractusx.irs.edc.client.EndpointDataReferenceStorage;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClientImpl;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClientLocalStub;
 import org.eclipse.tractusx.irs.registryclient.DigitalTwinRegistryService;
 import org.eclipse.tractusx.irs.registryclient.central.DigitalTwinRegistryClient;
 import org.eclipse.tractusx.irs.registryclient.central.DigitalTwinRegistryClientLocalStub;
@@ -160,5 +169,23 @@ public class JobConfiguration {
     @Bean
     public DigitalTwinRegistryClient digitalTwinRegistryClient(final CxTestDataContainer cxTestDataContainer) {
         return new DigitalTwinRegistryClientLocalStub(cxTestDataContainer);
+    }
+
+    @Profile({ "local",
+               "stubtest"
+    })
+    @Bean
+    public EdcSubmodelClient edcLocalSubmodelClient(final CxTestDataContainer cxTestDataContainer) {
+        return new EdcSubmodelClientLocalStub(cxTestDataContainer);
+    }
+
+    @Profile({ "!local && !stubtest" })
+    @Bean
+    public EdcSubmodelClient edcSubmodelClient(final EdcConfiguration edcConfiguration,
+            final ContractNegotiationService contractNegotiationService, final EdcDataPlaneClient edcDataPlaneClient,
+            final EndpointDataReferenceStorage endpointDataReferenceStorage, final AsyncPollingService pollingService,
+            final RetryRegistry retryRegistry, final EDCCatalogFacade catalogFacade) {
+        return new EdcSubmodelClientImpl(edcConfiguration, contractNegotiationService, edcDataPlaneClient,
+                endpointDataReferenceStorage, pollingService, retryRegistry, catalogFacade);
     }
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacade.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacade.java
@@ -28,16 +28,15 @@ import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
 import org.eclipse.tractusx.irs.edc.client.exceptions.EdcClientException;
 import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotification;
 import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotificationResponse;
 import org.eclipse.tractusx.irs.edc.client.model.notification.NotificationContent;
-import org.springframework.stereotype.Service;
 
 /**
  * Public API Facade for submodel domain
  */
-@Service("irsEdcClientEdcSubmodelFacade")
 @Slf4j
 @RequiredArgsConstructor
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SubmodelTestdataCreator.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SubmodelTestdataCreator.java
@@ -37,12 +37,13 @@ import org.eclipse.tractusx.irs.data.CxTestDataContainer;
  * Class to create Submodel Testdata
  * As AASWrapper is not deployed, we are using this class to Stub responses
  */
-class SubmodelTestdataCreator {
+public class SubmodelTestdataCreator {
 
     private final CxTestDataContainer cxTestDataContainer;
     private final ObjectMapper objectMapper;
 
-    /* package */ SubmodelTestdataCreator(final CxTestDataContainer cxTestDataContainer) {
+    /* package */
+    public SubmodelTestdataCreator(final CxTestDataContainer cxTestDataContainer) {
         this.cxTestDataContainer = cxTestDataContainer;
 
         objectMapper = new ObjectMapper();

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/edcsubmodelclient/EdcSubmodelClient.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/edcsubmodelclient/EdcSubmodelClient.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022,2023
+ *       2022: ZF Friedrichshafen AG
+ *       2022: ISTOS GmbH
+ *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2023: BOSCH AG
+ * Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.irs.edc.client.edcsubmodelclient;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.irs.edc.client.exceptions.EdcClientException;
+import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotification;
+import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotificationResponse;
+import org.eclipse.tractusx.irs.edc.client.model.notification.NotificationContent;
+
+/**
+ * Public API facade for EDC domain
+ */
+@SuppressWarnings("PMD.ExcessiveImports")
+public interface EdcSubmodelClient {
+
+    CompletableFuture<String> getSubmodelRawPayload(String connectorEndpoint, String submodelDataplaneUrl,
+            String assetId) throws EdcClientException;
+
+    CompletableFuture<EdcNotificationResponse> sendNotification(String submodelEndpointAddress, String assetId,
+            EdcNotification<NotificationContent> notification) throws EdcClientException;
+
+    CompletableFuture<EndpointDataReference> getEndpointReferenceForAsset(String endpointAddress, String filterKey,
+            String filterValue) throws EdcClientException;
+}
+

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/edcsubmodelclient/EdcSubmodelClientLocalStub.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/edcsubmodelclient/EdcSubmodelClientLocalStub.java
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022,2023
+ *       2022: ZF Friedrichshafen AG
+ *       2022: ISTOS GmbH
+ *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2023: BOSCH AG
+ * Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.irs.edc.client.edcsubmodelclient;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.irs.data.CxTestDataContainer;
+import org.eclipse.tractusx.irs.data.StringMapper;
+import org.eclipse.tractusx.irs.edc.client.SubmodelTestdataCreator;
+import org.eclipse.tractusx.irs.edc.client.exceptions.EdcClientException;
+import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotification;
+import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotificationResponse;
+import org.eclipse.tractusx.irs.edc.client.model.notification.NotificationContent;
+
+/**
+ * Submodel facade stub used in local environment
+ */
+public class EdcSubmodelClientLocalStub implements EdcSubmodelClient {
+
+    private final SubmodelTestdataCreator testdataCreator;
+
+    /* package */
+    public EdcSubmodelClientLocalStub(final CxTestDataContainer cxTestDataContainer) {
+        this.testdataCreator = new SubmodelTestdataCreator(cxTestDataContainer);
+    }
+
+    @Override
+    public CompletableFuture<String> getSubmodelRawPayload(final String connectorEndpoint,
+            final String submodelDataplaneUrl, final String assetId) throws EdcClientException {
+        if ("urn:uuid:c35ee875-5443-4a2d-bc14-fdacd64b9446".equals(assetId)) {
+            throw new EdcClientException("Dummy Exception");
+        }
+        final Map<String, Object> submodel = testdataCreator.createSubmodelForId(assetId + "_" + submodelDataplaneUrl);
+        return CompletableFuture.completedFuture(StringMapper.mapToString(submodel));
+    }
+
+    @Override
+    public CompletableFuture<EdcNotificationResponse> sendNotification(final String submodelEndpointAddress,
+            final String assetId, final EdcNotification<NotificationContent> notification) {
+        // not actually sending anything, just return success response
+        return CompletableFuture.completedFuture(() -> true);
+    }
+
+    @Override
+    public CompletableFuture<EndpointDataReference> getEndpointReferenceForAsset(final String endpointAddress,
+            final String filterKey, final String filterValue) throws EdcClientException {
+        throw new EdcClientException("Not implemented");
+    }
+}

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientTest.java
@@ -60,6 +60,8 @@ import org.eclipse.tractusx.irs.component.Relationship;
 import org.eclipse.tractusx.irs.component.enums.BomLifecycle;
 import org.eclipse.tractusx.irs.component.enums.Direction;
 import org.eclipse.tractusx.irs.data.StringMapper;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClientImpl;
 import org.eclipse.tractusx.irs.edc.client.exceptions.ContractNegotiationException;
 import org.eclipse.tractusx.irs.edc.client.exceptions.TimeoutException;
 import org.eclipse.tractusx.irs.edc.client.exceptions.TransferProcessException;

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacadeTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacadeTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.assertj.core.api.ThrowableAssert;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
 import org.eclipse.tractusx.irs.edc.client.exceptions.EdcClientException;
 import org.eclipse.tractusx.irs.edc.client.model.notification.EdcNotificationResponse;
 import org.junit.jupiter.api.Test;

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelFacadeWiremockTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelFacadeWiremockTest.java
@@ -53,6 +53,8 @@ import io.github.resilience4j.retry.RetryRegistry;
 import org.assertj.core.api.ThrowableAssert;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClientImpl;
 import org.eclipse.tractusx.irs.edc.client.exceptions.EdcClientException;
 import org.eclipse.tractusx.irs.edc.client.exceptions.UsagePolicyException;
 import org.eclipse.tractusx.irs.edc.client.policy.AcceptedPoliciesProvider;

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelRetryerTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelRetryerTest.java
@@ -35,6 +35,8 @@ import java.util.concurrent.Executors;
 
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.internal.InMemoryRetryRegistry;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClientImpl;
 import org.eclipse.tractusx.irs.edc.client.policy.PolicyCheckerService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientLocalStub.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientLocalStub.java
@@ -30,21 +30,16 @@ import org.eclipse.tractusx.irs.component.assetadministrationshell.AssetAdminist
 import org.eclipse.tractusx.irs.component.assetadministrationshell.IdentifierKeyValuePair;
 import org.eclipse.tractusx.irs.data.CxTestDataContainer;
 import org.eclipse.tractusx.irs.registryclient.decentral.LookupShellsResponse;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
 
 /**
  * Digital Twin Registry Rest Client Stub used in local environment
  */
-@Service
-@Profile({ "local",
-           "stubtest"
-})
-class DigitalTwinRegistryClientLocalStub implements DigitalTwinRegistryClient {
+public class DigitalTwinRegistryClientLocalStub implements DigitalTwinRegistryClient {
 
     private final AssetAdministrationShellTestdataCreator testdataCreator;
 
-    /* package */ DigitalTwinRegistryClientLocalStub(final CxTestDataContainer cxTestDataContainer) {
+    /* package */
+    public DigitalTwinRegistryClientLocalStub(final CxTestDataContainer cxTestDataContainer) {
         this.testdataCreator = new AssetAdministrationShellTestdataCreator(cxTestDataContainer);
     }
 

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/DefaultConfigurationTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/DefaultConfigurationTest.java
@@ -23,6 +23,7 @@
  ********************************************************************************/
 package org.eclipse.tractusx.irs.registryclient;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import org.eclipse.tractusx.irs.edc.client.EdcSubmodelFacade;
+import org.eclipse.tractusx.irs.edc.client.edcsubmodelclient.EdcSubmodelClient;
 import org.eclipse.tractusx.irs.edc.client.exceptions.EdcClientException;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestClientException;
@@ -61,6 +63,14 @@ class DefaultConfigurationTest {
                 testee.decentralDigitalTwinRegistryClient(new RestTemplate(), descriptorTemplate, shellLookupTemplate));
 
         assertThat(service).isNotNull();
+    }
+
+    @Test
+    void edcSubmodelFacade() {
+        final EdcSubmodelClient facadeMock = mock(EdcSubmodelClient.class);
+        final EdcSubmodelFacade edcSubmodelFacade = testee.edcSubmodelFacade(facadeMock);
+
+        assertThat(edcSubmodelFacade).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
* auto-detect bean removed from registry client
* bean creation moved to ...irs/configuration... package
* DigitalTwinRegistryClient stays in registry client since it is used in that package  

// **edit**
* all beans with required profile removed from irs-registry client (LocalTestDataConfiguration is left in test module, but since it is used only for testing I think this should not be a problem) 
* not sure how to test it properly, I've ran all tests + start irs-api app which uses irs-registry client and context seems to be correct - any ideas? 