### PR TITLE
Chore/#322 provisioning of contract negotiation and contract assessment for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added EDR token cache to reuse token after contract negotiation
 - Added cache mechanism in DiscoveryFinderClientImpl for findDiscoveryEndpoints
+- Add concept docs/#322-Provisioning-of-contractAgreementId-for-assets.md
 
 ## [4.3.0] - 2023-12-08
 ### Added

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -23,7 +23,7 @@
 # <ins>Overview</ins> <a name="overview"></a>
 The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
 This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the data after a successful check.
-During contract negotiation the edc stores audits the following artefacts edc:ContractAgreement and edc:ContractNegotiation these audit information could be requested over the edc management api. 
+During contract negotiation the edc stores audits to the artefacts edc:ContractAgreement and edc:ContractNegotiation. These audit information can be requested over the edc management API. 
 To request the mentioned artefacts over the management api the ContractAgreementDto:@id is required.
 This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
 

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -29,9 +29,9 @@ This specific id must therefore be stored and linked for the exchanged asset in 
 
 
 # <ins>Summary</ins> <a name="summary"></a>
-This feature provides the collecting of CIDs for contract negotiations regarding the EDD in the irs processing.
-The CIDs were provided in irs JobResponse document for collected assets. 
-For shells and submodels CID are collected and provided. 
+This feature is responsible for collecting the CIDs of EDC contract negotiations regarding during in the IRS processing.
+The CIDs are provided in the IRS JobResponse document for collected assets. 
+For shells and submodels CIDs are collected and provided. 
 In case of a usage policy mismatch. The irs policy store does not provide the usage policy of the asset. This circumstance is reported in a tombstone which contains the  policy of the asset. 
 
 # <ins>Problem Statement</ins> <a name="statement"></a>

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -59,10 +59,10 @@ In case of a usage policy mismatch. The irs policy store does not provide the us
 ## API Extensions 
 
 ## APIs 
-- <span style="color:green">POST</span> /irs/jobs 
-- <span style="color:green">POST</span> /irs/orders
-- <span style="color:green">POST</span> /irs/ess/orders
-- <span style="color:green">POST</span> /ess/bpn/investigation
+- POST /irs/jobs 
+- POST /irs/orders
+- POST /irs/ess/orders
+- POST /ess/bpn/investigation
 
 - parameter name: auditContractNegotiation 
 - parameter value: boolean value 

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -11,6 +11,10 @@
 - [ ] Should the EDC Management API of the IRS be configured in the business application or should the url be supplied via the JobResponse?
 - [ ] Does the business app have access to the management API of the EDC configured for the IRS
 - [ ] Is  a distinction is currently necessary for AAS accesses that are not traded via the EDC as we have not currently implemented the case in the IRS
+- [ ] Collect policy inside the IRS flow 
+- [ ] If contract negoation is not valid / not positive how we provide the contractAggreementId to the busines app? Exstend Tombstone extended. 
+- [ ] tombstone creation 
+
 
 # Table of Contents
 1. [Overview](#overview)
@@ -31,6 +35,7 @@ During contract negotation the edc stores audits the following artefacts edc:Con
 To request the mentioned artefacts over the management api the ContractAgreementDto:@id is required.
 This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
 
+
 # <ins>Summary</ins> <a name="summary"></a>
 
 # <ins>Problem Statement</ins> <a name="statement"></a>
@@ -50,22 +55,184 @@ This specific id must therefore be stored and linked for the exchanged asset in 
 
 # <ins>Concept</ins> <a name="concept"></a>
 
-## EDC Management API 
+## 1. Case 1: Successful contract negotiation 
+
+IRS proceed EDC contract negotiation succeeds.
+IRS transfers assets and collects contractAgreementId for asset
+
+### Receiving EndpointDataReference / EDR token for Catalog Entry 
+````mermaid
+
+sequenceDiagram
+    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px', 'fontFamily': 'Architects daughter'}}}%%
+    autonumber
+    SubmodelDelegate ->> EdcSubmodelFacade : getEndpointReferenceForAsset
+    EdcSubmodelFacade ->> EdcSubmodelClientImpl: getEndpointReferenceForAsset
+    note left of EdcSubmodelClientImpl: Get EDR token to call endpoint reference 
+    EdcSubmodelClientImpl ->> EDCCatalogFacade: fetchCatalogByFilter key/value 
+    EDCCatalogFacade ->> EdcControlPlaneClient: getCatalogWithFilter key/value
+    EdcControlPlaneClient ->> EDC Consumer ControlPlane : GET catalog with filter <br /> [POST /management/v2/catalog/request]
+    EDC Consumer ControlPlane ->> EdcControlPlaneClient : List<CatalogItems>
+    EdcControlPlaneClient ->> EDCCatalogFacade : List<CatalogItems>
+    EDCCatalogFacade ->> EdcSubmodelClientImpl : List<CatalogItems>
+    EdcSubmodelClientImpl --> ContractNegotiationService : do negotiation for List<CatalogItems>
+    ContractNegotiationService --> ContractNegotiationService : startNewNegotiation
+    ContractNegotiationService --> PolicyCheckerService : isValid 
+    alt is valid
+        ContractNegotiationService ->> EdcSubmodelClientImpl : return NegotiationResponse
+        ContractNegotiationService --> EdcSubmodelClientImpl : retrieve NegotiationResponse
+        EdcSubmodelClientImpl --> EdcSubmodelClientImpl : getContractAgreementId from  NegotiationResponse
+        EdcSubmodelClientImpl --> AsyncPollingService : retrieveEndpointReference
+        AsyncPollingService -->  EdcSubmodelClientImpl : EndpointDataReference
+        note left of EdcSubmodelClientImpl : received EDR Token to receive assets
+        EdcSubmodelClientImpl ->> EdcSubmodelFacade : EndpointDataReference
+        EdcSubmodelFacade ->> SubmodelDelegate : EndpointDataReference
+    else is not valid
+        ContractNegotiationService ->> ContractNegotiationService : throw UsagePolicyException
+        note right of ContractNegotiationService : UsagePolicyException MUST cover the policy of catalog item  this is relevant to create tombstone afterwards with policy
+        SubmodelDelegate --> ItemContainer: create tombstone with policy 
+    end
+        
+    
+````
+
+- [ ] TODO : EdcSubmodelFacade.getSubmodelRawPayload -> Payload of submodel
+- [ ] TODO : DecentralDigitalTwinRegistryService -> fetchShells : List keys  
+
+
+
+
+## 2. Case 2: IRS proceed EDC contract negotiation fails because of internal EDC error 
+## 3. Case 3: IRS proceed successful EDC contract negotiation and revokes asset transfers cause by not matching usage policy 
+
+In ContractNegotiationService startNewNegotiation if policy is not valid the policy of catalog item is returned. Tombstone with policy is created to display IRS requestor the catlogItem which could not be fetched because of invalid policy including their specific policy. 
+
+````mermaid
+
+sequenceDiagram
+    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px', 'fontFamily': 'Architects daughter'}}}%%
+    autonumber
+    ContractNegotiationService --> ContractNegotiationService : startNewNegotiation
+    ContractNegotiationService --> PolicyCheckerService : isValid
+    alt is valid
+        ContractNegotiationService ->> EdcSubmodelClientImpl : return NegotiationResponse
+        ContractNegotiationService --> EdcSubmodelClientImpl : retrieve NegotiationResponse
+        EdcSubmodelClientImpl --> EdcSubmodelClientImpl : getContractAgreementId from  NegotiationResponse
+        EdcSubmodelClientImpl --> AsyncPollingService : retrieveEndpointReference
+        AsyncPollingService -->  EdcSubmodelClientImpl : EndpointDataReference
+        note left of EdcSubmodelClientImpl : received EDR Token to receive assets
+        EdcSubmodelClientImpl ->> EdcSubmodelFacade : EndpointDataReference
+        EdcSubmodelFacade ->> IRS : EndpointDataReference
+    else is not valid
+        ContractNegotiationService ->> ContractNegotiationService : throw UsagePolicyException
+        note right of ContractNegotiationService : UsagePolicyException MUST cover the policy of catalog item  this is relevant to create tombstone afterwards with policy
+    end
+    SubmodelDelegate --> ItemContainer: create tombstone with raw policy information
+    
+````   
+
+- [ ] ContractNegotiationService adds policy information for catalog item to UsagePolicyException
+- [ ] Policy for catalog item is added to Tombstone in SubmodelDelegate
+
+
+## 4. Case 4: GET contract negotiation return 404 and "type": "ObjectNotFound", 
+
+````
+404
+ [
+	{
+		"message": "Object of type ContractNegotiation with ID=f9600523-f8e4-42b3-b388-485370b4f8f4 was not found",
+		"type": "ObjectNotFound",
+		"path": null,
+		"invalidValue": null
+	}
+]
+````
+
+## <ins>EDC Management API </ins>
 The EDC Management API is provided by EDC consumer. In this case the IRS configured EDC provider logs the required contract aggreements and provides the API to request contract agreements and contract negotations for given contract agreement @id
 
 Source: https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getNegotiationByAgreementId
-GET /v2/contractagreements/{id} Gets an contract agreement with the given ID
-GET /v2/contractagreements/{id}/negotiation Gets a contract negotiation with the given contract agreement ID
 
-## ContractAgreementId for AAS 
+```
+GET /v2/contractagreements/{id} 
+    Gets an contract agreement with the given ID
+GET /v2/contractagreements/{id}/negotiation
+    Gets a contract negotiation with the given contract agreement ID
+```
+
+## <ins>Mapping of contract ContractAgreementId in theJobResponse</ins>
+ 
+
+###  <ins>Add ContractAgreementId to shells  (AAS) </ins>
+The structure of the shells is extended in the same way as the submodels[] structure.
+The meta information, which is currently the "contractAgreementId", is written to the shells object. The actual payload of the shell is written to the payload object.
+This follows a uniform structure, as can also be found in the submodel object.
+
+```json 
+"shells": [
+		{
+			"contractAgreementId": "",
+			"payload": {
+				{
+					"administration": null,
+					...
+					"globalAssetId": "urn:uuid:a1fa0f85-697d-4c9d-982f-2501af8e8636",
+					"idShort": "VehicleCombustionA",
+					"id": "urn:uuid:56ee00a5-ca0f-4366-a00d-193e08e74995",
+					"specificAssetIds": [
+						{}
+					],
+					"submodelDescriptors": [
+						{}
+					]
+				}
+			}
+		},
+		{
+			"contractAgreementId": "",
+			"payload": {
+				{
+					// aas shell payload
+				}				
+		}	
+```
+
+###  <ins>Add ContractAgreementId to relationships</ins>
+In the first version, the ContractAgreementId is not mapped in the "relationship".
+If this information is required, the requester can register traversal aspect "SingleLevel*" in api parameter "aspects[]"
+in request POST /irs/jobs. This collects the submodel which include the required ContractAgreementId.
 
 
+````json
+"aspects": [
+"SingleLevelBomAsBuilt"
+]
+````
 
-## ContractAgreementId for submodels 
+### <ins>Add ContractAgreementId to submodels </ins>
 
-### Option 1: Provide submodel for  contractAgreementId 
+#### Option 1: Provide contractAgreementId for each submodel: 
 Impact: 
-1. High invasive changes to the code, api, JobResponse and documentation. 
+- Redundant information in case multiple submodels were received for the same contractAgreementId. 
+- JobReponse size is already critical and extends by ~100byte multiples with every submodel and aas shell stored in the JobReponse  
+
+```json 
+	"submodels": [
+      
+      {
+        "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
+        "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
+        "contractAgreementId": "<contractAgreementId>",
+        "payload": {
+            <... submodel payload ...>
+      }
+  ]
+```
+
+#### <ins>Option 2: Provide submodel for  contractAgreementId </ns>
+Impact:
+1. High invasive changes to the code, api, JobResponse and documentation.
 2. This variant complicates the optional (activatable/deactivatable) collection of ContractAggreementIds as these are an essential part of the response structure.
 
 ```json 
@@ -85,7 +252,7 @@ Impact:
   ]
 ```
 
-### Example 
+#### Example
 
 ```json 
   "contractAggreements" : [
@@ -104,37 +271,62 @@ Impact:
   ]
 ```
 
+### <ins>Add Tombstone in case of not matching policy</ins> 
+
+Tombstone is extended with policy payload when policy is not matched and contract negotiation is not conducted.
+The requestor gets the insight which policy does not match and has the opportunity to add the specific policy to the IRS policy store in order to receice further on assets with the specific policy. 
 
 
-
-### Option 2: Provide contractAgreementId for each submodel: 
-Impact: 
-- Redundant information in case multiple submodels were received for the same contractAgreementId. 
-- JobReponse size is already critical and extends by ~100byte multiples with every submodel and aas shell stored in the JobReponse  
-
-```json 
-	"submodels": [
-      
-      {
-        "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
-        "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
-        "contractAgreementId": "<contractAgreementId>",
-        "payload": {
-            <... submodel payload ...>
+`````json 
+"tombstones": [
+    {
+      "catenaXId": "urn:uuid:6ce41c0b-c84a-46b0-b4c4-78fce958663d", 
+      "endpointURL": null,
+      "policy": {
+            "odrl:hasPolicy": {
+                "@id": "ZDgzZjhjY2EtMGY2MC00OWMzLWJjNDYtMWE0OTY2MDdlMzhj:cmVnaXN0cnktYXNzZXQ=:Y2IxNzI5MjUtYzUyNS00NmJiLWFiZWQtMDVhMTdkNTFiZTg0",
+                "@type": "odrl:Set",
+                "odrl:permission": {
+                  "odrl:target": "registry-asset",
+                  "odrl:action": {
+                      "odrl:type": "USE"
+                  },
+                  "odrl:constraint": {
+                      "odrl:or": {
+                      "odrl:leftOperand": "PURPOSE",
+                      "odrl:operator": {
+                      "@id": "odrl:eq"
+                  },
+                    "odrl:rightOperand": "ID 3.0 Trace"
+                  }
+              }
+         }
+      },         
+      "processingError": {
+          "processStep": "DigitalTwinRequest",
+          "errorDetail": "EndpointDataReference was not found. Requested connectorEndpoints: https://dsi-int-2-1llhjasi.c-5e7e41f.stage.kyma.ondemand.com, https://sap-3-2-ap-edc1-cp.foss.cx.shoot.live.k8s-hana.ondemand.com",
+          "lastAttempt": "2024-01-17T09:02:36.648055745Z",
+          "retryCounter": 3
       }
-  ]
-```
+    }
+],
+
+`````
+
+
 
 
 # <ins>Glossary</ins> <a name="glossary"></a>
 
-| Abbreviation           | Name                     |
-|------------------------|--------------------------|
-| edc:ContractAgreement  |                          |
-| edc:ContractNegotation |                          |
-| AAS                    | AssetAdministrationShell |   
- | contractAgreementId   |                          |
+| Abbreviation           | Name                               |
+|------------------------|------------------------------------|
+| edc:ContractAgreement  |                                    |
+| edc:ContractNegotation |                                    |
+| AAS                    | AssetAdministrationShell           |   
+| contractAgreementId    | Unique Id of an contract aggrement |
 
 # <ins>References</ins> <a name="references"></a>
 
 https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getAgreementById
+https://github.com/eclipse-tractusx/tractusx-edc/blob/main/docs/kit/Development%20View/01_MGMT_API_Walkthrough/02_policies.md
+https://eclipse-edc.github.io/docs/#/submodule/Connector/docs/developer/contracts

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -1,15 +1,16 @@
 # \[Concept\] \[#ID#\] Summary 
 
-| Key           | Value             |
-|---------------|-------------------|
-| Creation date | 11.01.2024        |
-| Ticket Id     | https://github.com/eclipse-tractusx/item-relationship-service/issues/322        |    
-| State        | <DRAFT,WIP, DONE> | 
+| Key            | Value             |
+|----------------|-------------------|
+| Creation date  | 11.01.2024        |
+| Ticket Id      | https://github.com/eclipse-tractusx/item-relationship-service/issues/322        |    
+| State          | <DRAFT,WIP, DONE> | 
 
 # LOP <TO be deleted>
 - [ ] Can Trace-X access the management API of the IRS EDC?
 - [ ] Should the EDC Management API of the IRS be configured in the business application or should the url be supplied via the JobResponse?
 - [ ] Does the business app have access to the management API of the EDC configured for the IRS
+- [ ] Is  a distinction is currently necessary for AAS accesses that are not traded via the EDC as we have not currently implemented the case in the IRS
 
 # Table of Contents
 1. [Overview](#overview)
@@ -50,6 +51,8 @@ This specific id must therefore be stored and linked for the exchanged asset in 
 # <ins>Concept</ins> <a name="concept"></a>
 
 ## EDC Management API 
+The EDC Management API is provided by EDC consumer. In this case the IRS configured EDC provider logs the required contract aggreements and provides the API to request contract agreements and contract negotations for given contract agreement @id
+
 Source: https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getNegotiationByAgreementId
 GET /v2/contractagreements/{id} Gets an contract agreement with the given ID
 GET /v2/contractagreements/{id}/negotiation Gets a contract negotiation with the given contract agreement ID
@@ -61,7 +64,9 @@ GET /v2/contractagreements/{id}/negotiation Gets a contract negotiation with the
 ## ContractAgreementId for submodels 
 
 ### Option 1: Provide submodel for  contractAgreementId 
-Impact: High invasive changes to the code, api, JobResponse and documentation. 
+Impact: 
+1. High invasive changes to the code, api, JobResponse and documentation. 
+2. This variant complicates the optional (activatable/deactivatable) collection of ContractAggreementIds as these are an essential part of the response structure.
 
 ```json 
   "contractAggreements" : [

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -82,7 +82,7 @@ IRS transfers assets and collects contractAgreementId for asset
 ````mermaid
 
 sequenceDiagram
-    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px', 'fontFamily': 'Architects daughter'}}}%%
+    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px'}}}%%
     autonumber
     SubmodelDelegate ->> EdcSubmodelFacade : getEndpointReferenceForAsset
     EdcSubmodelFacade ->> EdcSubmodelClientImpl: getEndpointReferenceForAsset
@@ -119,7 +119,7 @@ sequenceDiagram
 ````mermaid
 
 sequenceDiagram
-    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px', 'fontFamily': 'Architects daughter'}}}%%
+    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px'}}}%%
     autonumber
     IRS ->> SubmodelDelegate : process 
     SubmodelDelegate ->> SubmodelDelegate : getSubmodels
@@ -167,7 +167,7 @@ In ContractNegotiationService startNewNegotiation if policy is not valid the pol
 ````mermaid
 
 sequenceDiagram
-    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px', 'fontFamily': 'Architects daughter'}}}%%
+    %%{init: {'theme': 'dark', 'themeVariables': { 'fontSize': '15px'}}}%%
     autonumber
     ContractNegotiationService ->> ContractNegotiationService : startNewNegotiation
     ContractNegotiationService ->> PolicyCheckerService : isValid

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -6,6 +6,11 @@
 | Ticket Id     | https://github.com/eclipse-tractusx/item-relationship-service/issues/322        |    
 | State        | <DRAFT,WIP, DONE> | 
 
+# LOP <TO be deleted>
+- [ ] Can Trace-X access the management API of the IRS EDC?
+- [ ] Should the EDC Management API of the IRS be configured in the business application or should the url be supplied via the JobResponse?
+- [ ] Does the business app have access to the management API of the EDC configured for the IRS
+
 # Table of Contents
 1. [Overview](#overview)
 2. [Summary](#summary)
@@ -19,15 +24,23 @@
 
 # <ins>Overview</ins> <a name="overview"></a>
 The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
-This access is automatically checked by the EDC via so-called AccessPolicies. The conument is only granted access to the data after a successful check.
+This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the data after a successful check.
+During contract negotation the edc stores audits the following artefacts edc:ContractAgreement and edc:ContractNegotation these audit information could be requested over the edc management api. 
+To request the mentioned artefacts over the management api the ContractAgreementDto:@id is required.
+This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
 
 # <ins>Summary</ins> <a name="summary"></a>
 
 # <ins>Problem Statement</ins> <a name="statement"></a>
+1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS cannot access the corresponding ContractAggreement under which the assets delivered by the IRS were exchanged.
+2. The EDC management api does not provide any endpoint to query a contract agreement using an asset id.
+3. Business apps must make the contract agreements under which the assets were exchanged available for audit purposes.
 
 # <ins>Requirements</ins> <a name="requirements"></a>
 
-1. Provisioning of ContractAgreementDto:@id via IRS JobReponse.
+1. [ ] Provisioning of ContractAgreementDto:@id via IRS JobReponse for AAS retrieved via EDC.
+2. [ ] Provisioning of ContractAgreementDto:@id via IRS JobReponse for submodels retrieved via EDC.
+3. [ ] API parameter SHOULD control whether ContractAgreementDto:@id should be returned via the IRSJobResponse
 
 # <ins>NFR</ins> <a name="nfr"></a>
 
@@ -35,9 +48,52 @@ This access is automatically checked by the EDC via so-called AccessPolicies. Th
 
 # <ins>Concept</ins> <a name="concept"></a>
 
+
+## ContractAgreementId for submodels 
+
+### Option 1: Provide submodel for  contractAgreementId 
+Impact: High invasive changes to the code, api, JobResponse and documentation. 
+
+```json 
+  "contractAggreements" : [
+    "contractAggreement" : {
+       "contractAgreementId": "<contractAgreementId>",
+       "submodels": [
+        {
+            "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
+            "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
+            "payload": {
+              <... submodel payload ...>
+        }
+      ] 
+    }     
+        
+  ]
+```
+
+### Option 2: Provide contractAgreementId for each submodel: 
+Impact: 
+- Redundant information in case multiple submodels were received for the same contractAgreementId. 
+- JobReponse size is already critical and extends by ~100byte multiples with every submodel and aas shell stored in the JobReponse  
+
+```json 
+	"submodels": [
+      
+      {
+        "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
+        "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
+        "contractAgreementId": "<contractAgreementId>",
+        "payload": {
+            <... submodel payload ...>
+      }
+  ]
+```
+
 # <ins>Glossary</ins> <a name="glossary"></a>
 
-| Abbreviation | Name                        |
-|-------------|-----------------------------|
-|   |  |
-|   |  |
+| Abbreviation           | Name                     |
+|------------------------|--------------------------|
+| edc:ContractAgreement  |                          |
+| edc:ContractNegotation |                          |
+| AAS                    | AssetAdministrationShell |   
+ | contractAgreementId   |                          |

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -35,7 +35,7 @@ For shells and submodels CIDs are collected and provided.
 In case of a usage policy mismatch. The irs policy store does not provide the usage policy of the asset. This circumstance is reported in a tombstone which contains the  policy of the asset. 
 
 # <ins>Problem Statement</ins> <a name="statement"></a>
-1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS cannot access the corresponding ContractAggreement under which the assets delivered by the IRS were exchanged.
+1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS cannot access the corresponding ContractAggreement under which the assets, delivered by the IRS, were exchanged.
 2. The EDC management api does not provide any endpoint to query a contract agreement using an asset id.
 3. Business apps must make the contract agreements under which the assets were exchanged available for audit purposes.
 

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -1,0 +1,38 @@
+# \[Concept\] \[#ID#\] Summary 
+
+| Key           | Value             |
+|---------------|-------------------|
+| Creation date | <DD.MM.YYYY>      |
+| Ticket Id     | <ID> <url>        |    
+| State        | <DRAFT,WIP, DONE> | 
+
+# Table of Contents
+1. [Overview](#overview)
+2. [Summary](#summary)
+3. [Problem Statement](#statement)
+4. [Requirements](#requirements)
+5. [NFR](#nfr)
+6. [Concept](#concept)
+7. [Glossary](#glossary)
+
+
+# <ins>Overview</ins> <a name="overview"></a>
+
+
+# <ins>Summarny</ins> <a name="summary"></a>
+
+# <ins>Problem Statement</ins> <a name="statement"></a>
+
+# <ins>Requirements</ins> <a name="requirements"></a>
+
+# <ins>NFR</ins> <a name="nfr"></a>
+
+# <ins>Concept</ins> <a name="concept"></a>
+
+
+# <ins>Glossary</ins> <a name="glossary"></a>
+
+| Abbreviation | Name                        |
+|-------------|-----------------------------|
+|   |  |
+|   |  |

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -20,6 +20,7 @@
 6. [Out of scope](#outofscope)
 7. [Concept](#concept)
 8. [Glossary](#glossary)
+9. [References](#references)
 
 
 # <ins>Overview</ins> <a name="overview"></a>
@@ -48,6 +49,14 @@ This specific id must therefore be stored and linked for the exchanged asset in 
 
 # <ins>Concept</ins> <a name="concept"></a>
 
+## EDC Management API 
+Source: https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getNegotiationByAgreementId
+GET /v2/contractagreements/{id} Gets an contract agreement with the given ID
+GET /v2/contractagreements/{id}/negotiation Gets a contract negotiation with the given contract agreement ID
+
+## ContractAgreementId for AAS 
+
+
 
 ## ContractAgreementId for submodels 
 
@@ -60,6 +69,25 @@ Impact: High invasive changes to the code, api, JobResponse and documentation.
        "contractAgreementId": "<contractAgreementId>",
        "submodels": [
         {
+            "identification": "<identification>>",
+            "aspectType": "<aspectType>",
+            "payload": {
+              <... submodel payload ...>
+        }
+      ] 
+    }     
+        
+  ]
+```
+
+### Example 
+
+```json 
+  "contractAggreements" : [
+    "contractAggreement" : {
+       "contractAgreementId": "YjA4NjdmMjgtYWMwMC00OTdiLTliMTItNGEzZDdkYjk4YmEw:cmVnaXN0cnktYXNzZXQ=:YWI2MTY5ZDctNzdiYi00YTQ1LTljZTYtZTUzZjhjM2MwYTFm",
+       "submodels": [
+        {
             "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
             "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
             "payload": {
@@ -70,6 +98,9 @@ Impact: High invasive changes to the code, api, JobResponse and documentation.
         
   ]
 ```
+
+
+
 
 ### Option 2: Provide contractAgreementId for each submodel: 
 Impact: 
@@ -89,6 +120,7 @@ Impact:
   ]
 ```
 
+
 # <ins>Glossary</ins> <a name="glossary"></a>
 
 | Abbreviation           | Name                     |
@@ -97,3 +129,7 @@ Impact:
 | edc:ContractNegotation |                          |
 | AAS                    | AssetAdministrationShell |   
  | contractAgreementId   |                          |
+
+# <ins>References</ins> <a name="references"></a>
+
+https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getAgreementById

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -23,12 +23,16 @@
 # <ins>Overview</ins> <a name="overview"></a>
 The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
 This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the data after a successful check.
-During contract negotation the edc stores audits the following artefacts edc:ContractAgreement and edc:ContractNegotation these audit information could be requested over the edc management api. 
+During contract negotiation the edc stores audits the following artefacts edc:ContractAgreement and edc:ContractNegotiation these audit information could be requested over the edc management api. 
 To request the mentioned artefacts over the management api the ContractAgreementDto:@id is required.
 This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
 
 
 # <ins>Summary</ins> <a name="summary"></a>
+This feature provides the collecting of CIDs for contract negotiations regarding the EDD in the irs processing.
+The CIDs were provided in irs JobResponse document for collected assets. 
+For shells and submodels CID are collected and provided. 
+In case of a usage policy mismatch. The irs policy store does not provide the usage policy of the asset. This circumstance is reported in a tombstone which contains the  policy of the asset. 
 
 # <ins>Problem Statement</ins> <a name="statement"></a>
 1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS cannot access the corresponding ContractAggreement under which the assets delivered by the IRS were exchanged.

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -2,8 +2,8 @@
 
 | Key           | Value             |
 |---------------|-------------------|
-| Creation date | <DD.MM.YYYY>      |
-| Ticket Id     | <ID> <url>        |    
+| Creation date | 11.01.2024        |
+| Ticket Id     | https://github.com/eclipse-tractusx/item-relationship-service/issues/322        |    
 | State        | <DRAFT,WIP, DONE> | 
 
 # Table of Contents
@@ -12,23 +12,28 @@
 3. [Problem Statement](#statement)
 4. [Requirements](#requirements)
 5. [NFR](#nfr)
-6. [Concept](#concept)
-7. [Glossary](#glossary)
+6. [Out of scope](#outofscope)
+7. [Concept](#concept)
+8. [Glossary](#glossary)
 
 
 # <ins>Overview</ins> <a name="overview"></a>
+The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
+This access is automatically checked by the EDC via so-called AccessPolicies. The conument is only granted access to the data after a successful check.
 
-
-# <ins>Summarny</ins> <a name="summary"></a>
+# <ins>Summary</ins> <a name="summary"></a>
 
 # <ins>Problem Statement</ins> <a name="statement"></a>
 
 # <ins>Requirements</ins> <a name="requirements"></a>
 
+1. Provisioning of ContractAgreementDto:@id via IRS JobReponse.
+
 # <ins>NFR</ins> <a name="nfr"></a>
 
-# <ins>Concept</ins> <a name="concept"></a>
+# <ins>Out of scope</ins> <a name="outofscope"></a>
 
+# <ins>Concept</ins> <a name="concept"></a>
 
 # <ins>Glossary</ins> <a name="glossary"></a>
 

--- a/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contract-definiton-for-assets/#322-Provisioning-of-contract-definiton-for-assets.md
@@ -24,7 +24,7 @@
 The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
 This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the data after a successful check.
 During contract negotiation the edc stores audits to the artefacts edc:ContractAgreement and edc:ContractNegotiation. These audit information can be requested over the edc management API. 
-To request the mentioned artefacts over the management api the ContractAgreementDto:@id is required.
+To request the mentioned artefacts over the management API the ContractAgreementDto:@id is required.
 This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
 
 

--- a/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
@@ -70,7 +70,6 @@ In case of a usage policy mismatch. The irs policy store does not provide the us
 - parameter description: enables and disables auditing including provisioning of ContractAgreementId inside submodels and shells objects
 - parameter impacts: enables collection of ContractAgreementId in job processing and provides this information in submodelContainers and ShellContainers as well in Tombstone in case policy does not match or other internal error during EDC communication. 
 
-
 ## 1. Case 1: Successful contract negotiation 
 
 IRS proceed EDC contract negotiation succeeds.

--- a/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
@@ -1,4 +1,4 @@
-# \[Concept\] \[#ID#\] Summary 
+# Concept #322 Provisioning of contract agreement id for assets
 
 | Key           | Value            |
 |---------------|------------------|

--- a/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
@@ -10,17 +10,17 @@
 # Table of Contents
 1. [Overview](#overview)
 2. [Summary](#summary)
-3. [Problem Statement](#statement)
+3. [Problem Statement](#problem-statement)
 4. [Requirements](#requirements)
 5. [NFR](#nfr)
-6. [Out of scope](#outofscope)
+6. [Out of scope](#out-of-scope)
 7. [Assumptions](#assumptions)
 8. [Concept](#concept)
 9. [Glossary](#glossary)
 10. [References](#references)
 
 
-# <ins>Overview</ins> <a name="overview"></a>
+# <ins>Overview</ins> 
 The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
 This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the data after a successful check.
 During contract negotiation the edc stores audits to the artefacts edc:ContractAgreement and edc:ContractNegotiation. These audit information can be requested over the edc management API. 
@@ -28,28 +28,28 @@ To request the mentioned artefacts over the management API the ContractAgreement
 This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
 
 
-# <ins>Summary</ins> <a name="summary"></a>
+# <ins>Summary</ins>
 This feature is responsible for collecting the CIDs of EDC contract negotiations regarding during in the IRS processing.
 The CIDs are provided in the IRS JobResponse document for collected assets. 
 For shells and submodels CIDs are collected and provided. 
 In case of a usage policy mismatch. The irs policy store does not provide the usage policy of the asset. This circumstance is reported in a tombstone which contains the  policy of the asset. 
 
-# <ins>Problem Statement</ins> <a name="statement"></a>
+# <ins>Problem Statement</ins> 
 1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS cannot access the corresponding ContractAggreement under which the assets, delivered by the IRS, were exchanged.
 2. The EDC management api does not provide any endpoint to query a contract agreement using an asset id.
 3. Business apps must make the contract agreements under which the assets were exchanged available for audit purposes.
 
-# <ins>Requirements</ins> <a name="requirements"></a>
+# <ins>Requirements</ins> 
 
 1. [ ] Provisioning of ContractAgreementDto:@id via IRS JobReponse for AAS retrieved via EDC.
 2. [ ] Provisioning of ContractAgreementDto:@id via IRS JobReponse for submodels retrieved via EDC.
 3. [ ] API parameter SHOULD control whether ContractAgreementDto:@id should be returned via the IRSJobResponse
 
-# <ins>NFR</ins> <a name="nfr"></a>
+# <ins>NFR</ins> 
 
-# <ins>Out of scope</ins> <a name="outofscope"></a>
+# <ins>Out of scope</ins>
 
-# <ins>Assumptions</ins> <a name="assumptions"></a>
+# <ins>Assumptions</ins> >
 - [x] Business app (Trace-X) has access to the management API of the IRS EDC Consumer. 
 - [x] EDC Management API of EDC Consumer is configured as a parameter in Business app (Trace-X). IRS does not provide API url to EDC Management API via JobResponse.
 - [x] In case there os no valid negotation including contract agreement policy of catalog offer will be collected inside IRS flow and provided to irs requestor.
@@ -69,7 +69,6 @@ In case of a usage policy mismatch. The irs policy store does not provide the us
 - parameter default: true 
 - parameter description: enables and disables auditing including provisioning of ContractAgreementId inside submodels and shells objects
 - parameter impacts: enables collection of ContractAgreementId in job processing and provides this information in submodelContainers and ShellContainers as well in Tombstone in case policy does not match or other internal error during EDC communication. 
-
 
 
 ## 1. Case 1: Successful contract negotiation 

--- a/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
@@ -1,13 +1,13 @@
 # Concept #322 Provisioning of contract agreement id for assets
 
-| Key           | Value          |
-|---------------|----------------|
-| Creation date | 11.01.2024     |
-| Issue Id      | https://github.com/eclipse-tractusx/item-relationship-service/issues/322   https://github.com/eclipse-tractusx/item-relationship-service/issues/370  |    
-| State         | DRAFT | 
-
+| Key           | Value                                                                                                                                               |
+|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Creation date | 11.01.2024                                                                                                                                          |
+| Issue Id      | https://github.com/eclipse-tractusx/item-relationship-service/issues/322   https://github.com/eclipse-tractusx/item-relationship-service/issues/370 |    
+| State         | DRAFT                                                                                                                                               | 
 
 # Table of Contents
+
 1. [Overview](#overview)
 2. [Summary](#summary)
 3. [Problem Statement](#problem-statement)
@@ -19,64 +19,78 @@
 9. [Glossary](#glossary)
 10. [References](#references)
 
+# Overview
 
-# <ins>Overview</ins> 
-The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether the consumer has authorized access to the data asset.
-This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the data after a successful check.
-During contract negotiation the edc stores audits to the artefacts edc:ContractAgreement and edc:ContractNegotiation. These audit information can be requested over the edc management API. 
+The exchange of assets via the EDC takes place after a successful contract negotiation in which it is checked whether
+the consumer has authorized access to the data asset.
+This access is automatically checked by the EDC via so-called AccessPolicies. The consumer is only granted access to the
+data after a successful check.
+During contract negotiation the edc stores audits to the artefacts edc:ContractAgreement and edc:ContractNegotiation.
+These audit information can be requested over the edc management API.
 To request the mentioned artefacts over the management API the ContractAgreementDto:@id is required.
-This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the corresponding contract agreement later on.
+This specific id must therefore be stored and linked for the exchanged asset in order to be able to determine the
+corresponding contract agreement later on.
 
+# Summary
 
-# <ins>Summary</ins>
 This feature is responsible for collecting the CIDs of EDC contract negotiations regarding during in the IRS processing.
-The CIDs are provided in the IRS JobResponse document for collected assets. 
-For shells and submodels CIDs are collected and provided. 
-In case of a usage policy mismatch. The irs policy store does not provide the usage policy of the asset. This circumstance is reported in a tombstone which contains the  policy of the asset. 
+The CIDs are provided in the IRS JobResponse document for collected assets.
+For shells and submodels CIDs are collected and provided.
+In case of a usage policy mismatch. The irs policy store does not provide the usage policy of the asset. This
+circumstance is reported in a tombstone which contains the policy of the asset.
 
-# <ins>Problem Statement</ins> 
-1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS cannot access the corresponding ContractAggreement under which the assets, delivered by the IRS, were exchanged.
-2. Teh EDC management API provides a endpoint ro query contract agreement by assetId. It is not possible to determine which ContractAggreement belongs to which negotiation in case of multiple negotiations for the same asset
+# Problem Statement
+
+1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS
+   cannot access the corresponding ContractAggreement under which the assets, delivered by the IRS, were exchanged.
+2. Teh EDC management API provides a endpoint ro query contract agreement by assetId. It is not possible to determine
+   which ContractAggreement belongs to which negotiation in case of multiple negotiations for the same asset
 3. Business apps must make the contract agreements under which the assets were exchanged available for audit purposes.
 
-# <ins>Requirements</ins> 
+# Requirements
 
 1. [ ] Provisioning of ContractAgreementDto:@id via IRS JobReponse for AAS retrieved via EDC.
 2. [ ] Provisioning of ContractAgreementDto:@id via IRS JobReponse for submodels retrieved via EDC.
 3. [ ] API parameter SHOULD control whether ContractAgreementDto:@id should be returned via the IRSJobResponse
 
-# <ins>NFR</ins> 
+# NFR
 
-# <ins>Out of scope</ins>
+# Out of scope
 
-# <ins>Assumptions</ins> >
-- [x] Business app (Trace-X) has access to the management API of the IRS EDC Consumer. 
-- [x] EDC Management API of EDC Consumer is configured as a parameter in Business app (Trace-X). IRS does not provide API url to EDC Management API via JobResponse.
-- [x] In case there negotiation is not executed because of policy mismatch, the catalog offer policy of will be collected inside IRS flow and provided to irs requestor.
+# Assumptions
 
-# <ins>Concept</ins> <a name="concept"></a>
+- [x] Business app (Trace-X) has access to the management API of the IRS EDC Consumer.
+- [x] EDC Management API of EDC Consumer is configured as a parameter in Business app (Trace-X). IRS does not provide
+  API url to EDC Management API via JobResponse.
+- [x] In case there negotiation is not executed because of policy mismatch, the catalog offer policy of will be
+  collected inside IRS flow and provided to irs requestor.
 
+# Concept
 
-## API Extensions 
+## API Extensions
 
-## APIs 
-- POST /irs/jobs 
+## APIs
+
+- POST /irs/jobs
 - POST /irs/orders
 - POST /irs/ess/orders
 - POST /ess/bpn/investigation
 
-- parameter name: auditContractNegotiation 
-- parameter value: boolean value 
-- parameter default: true 
-- parameter description: enables and disables auditing including provisioning of ContractAgreementId inside submodels and shells objects
-- parameter impacts: enables collection of ContractAgreementId in job processing and provides this information in SubmodelContainers and ShellContainers or policy from CatalogOffer in Tombstone in case of policy mismatch  
+- parameter name: auditContractNegotiation
+- parameter value: boolean value
+- parameter default: true
+- parameter description: enables and disables auditing including provisioning of ContractAgreementId inside submodels
+  and shells objects
+- parameter impacts: enables collection of ContractAgreementId in job processing and provides this information in
+  SubmodelContainers and ShellContainers or policy from CatalogOffer in Tombstone in case of policy mismatch
 
-## 1. Case 1: Successful contract negotiation 
+## 1. Case 1: Successful contract negotiation
 
 IRS proceed EDC contract negotiation succeeds.
 IRS transfers assets and collects contractAgreementId for asset
 
-### Receiving EndpointDataReference / EDR token for Catalog Entry 
+### Receiving EndpointDataReference / EDR token for Catalog Entry
+
 ````mermaid
 
 sequenceDiagram
@@ -107,11 +121,9 @@ sequenceDiagram
         note right of ContractNegotiationService : UsagePolicyException MUST cover the policy of catalog item  this is relevant to create tombstone afterwards with policy
         SubmodelDelegate --> ItemContainer: create tombstone with policy payload
     end
-        
-    
 ````
 
-### Receiving Submodel Payload 
+### Receiving Submodel Payload
 
 ````mermaid
 
@@ -129,6 +141,7 @@ sequenceDiagram
     EdcSubmodelFacade -->> SubmodelDelegate: submodel payload
     SubmodelDelegate -->> IRS: write contractAgreementId to JobReponse submodels[]
 ````
+
 ### Receiving AAS Payload
 
 ````mermaid
@@ -147,7 +160,6 @@ sequenceDiagram
     DigitalTwinRegistryService -->> IRS :  write contractAgreementId to JobReponse shells array
     
 ````   
-
 
 ````mermaid
 
@@ -176,28 +188,25 @@ sequenceDiagram
     SubmodelDelegate --> IRS : write contractAgreementÍd to submodel inside JobReponse
 ````   
 
-
-## 2. Case 2: IRS proceed EDC contract negotiation fails because of internal EDC error 
+## 2. Case 2: IRS proceed EDC contract negotiation fails because of internal EDC error
 
 ### Case 2.1: GET contract negotiation return 404 and "type": "ObjectNotFound",
 
 ````
 404
- [
-	{
-		"message": "Object of type ContractNegotiation with ID=f9600523-f8e4-42b3-b388-485370b4f8f4 was not found",
-		"type": "ObjectNotFound",
-		"path": null,
-		"invalidValue": null
-	}
+[
+  {
+    "message": "Object of type ContractNegotiation with ID=f9600523-f8e4-42b3-b388-485370b4f8f4 was not found",
+    "type": "ObjectNotFound",
+    "path": null,
+    "invalidValue": null
+  }
 ]
 ````
 
-## 3. Case 3: IRS revokes asset transfers cause by not matching usage policy 
+## 3. Case 3: IRS revokes asset transfers cause by not matching usage policy
 
-
-Usage policy is checked before contract negotiation. in case policy mismatch, no negotiation will be started. 
-
+Usage policy is checked before contract negotiation. in case policy mismatch, no negotiation will be started.
 
 ````mermaid
 
@@ -223,9 +232,11 @@ end
 
 ````
 
+## EDC Management API 
 
-## <ins>EDC Management API </ins>
-The EDC Management API is provided by EDC consumer. In this case the IRS configured EDC provider logs the required contract aggreements and provides the API to request contract agreements and contract negotations for given contract agreement @id
+The EDC Management API is provided by EDC consumer. In this case the IRS configured EDC provider logs the required
+contract aggreements and provides the API to request contract agreements and contract negotations for given contract
+agreement @id
 
 Source: https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getNegotiationByAgreementId
 
@@ -236,150 +247,159 @@ GET /v2/contractagreements/{id}/negotiation
     Gets a contract negotiation with the given contract agreement ID
 ```
 
-## <ins>Mapping of contract ContractAgreementId in theJobResponse</ins>
- 
+## Mapping of contract ContractAgreementId in theJobResponse
 
-###  <ins>Add ContractAgreementId to shells  (AAS) </ins>
+### Add ContractAgreementId to shells (AAS) 
+
 The structure of the shells is extended in the same way as the submodels[] structure.
-The meta information, which is currently the "contractAgreementId", is written to the shells object. The actual payload of the shell is written to the payload object.
+The meta information, which is currently the "contractAgreementId", is written to the shells object. The actual payload
+of the shell is written to the payload object.
 This follows a uniform structure, as can also be found in the submodel object.
 
 ```json 
 "shells": [
-		{
-			"contractAgreementId": "",
-			"payload": {
-				{
-					"administration": null,
-					...
-					"globalAssetId": "urn:uuid:a1fa0f85-697d-4c9d-982f-2501af8e8636",
-					"idShort": "VehicleCombustionA",
-					"id": "urn:uuid:56ee00a5-ca0f-4366-a00d-193e08e74995",
-					"specificAssetIds": [
-						{}
-					],
-					"submodelDescriptors": [
-						{}
-					]
-				}
-			}
-		},
-		{
-			"contractAgreementId": "",
-			"payload": {
-				{
-					// aas shell payload
-				}				
-		}	
+  {
+    "contractAgreementId": "",
+    "payload": {
+      {
+        "administration": null,
+        ...
+        "globalAssetId": "urn:uuid:a1fa0f85-697d-4c9d-982f-2501af8e8636",
+        "idShort": "VehicleCombustionA",
+        "id": "urn:uuid:56ee00a5-ca0f-4366-a00d-193e08e74995",
+        "specificAssetIds": [
+          {}
+        ],
+        "submodelDescriptors": [
+          {}
+        ]
+      }
+    }
+  },
+  {
+    "contractAgreementId": "",
+    "payload": {
+      // aas shell payload
+    }				
+  }
+]
 ```
 
-###  <ins>Add ContractAgreementId to relationships</ins>
+### Add ContractAgreementId to relationships
+
 In the first version, the ContractAgreementId is not mapped in the "relationship".
 If this information is required, the requester can register traversal aspect "SingleLevel*" in api parameter "aspects[]"
 in request POST /irs/jobs. This collects the submodel which include the required ContractAgreementId.
 
-
 ````json
 "aspects": [
-"SingleLevelBomAsBuilt"
+  "SingleLevelBomAsBuilt"
 ]
 ````
 
-### <ins>Add ContractAgreementId to submodels </ins>
+### Add ContractAgreementId to submodels 
 
-#### Option 1: Provide contractAgreementId for each submodel: 
-Impact: 
-- Redundant information in case multiple submodels were received for the same contractAgreementId. 
-- JobReponse size is already critical and extends by ~100byte multiples with every submodel and aas shell stored in the JobReponse  
+#### Option 1: Provide contractAgreementId for each submodel:
 
-```json 
-	"submodels": [
-      
-      {
-        "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
-        "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
-        "contractAgreementId": "<contractAgreementId>",
-        "payload": {
-            <... submodel payload ...>
-      }
-  ]
-```
-
-#### <ins>Option 2: Provide submodel for  contractAgreementId </ns>
 Impact:
-1. High invasive changes to the code, api, JobResponse and documentation.
-2. This variant complicates the optional (activatable/deactivatable) collection of ContractAggreementIds as these are an essential part of the response structure.
+
+- Redundant information in case multiple submodels were received for the same contractAgreementId.
+- JobReponse size is already critical and extends by ~100byte multiples with every submodel and aas shell stored in the
+  JobReponse
 
 ```json 
-  "contractAggreements" : [
-    "contractAggreement" : {
-       "contractAgreementId": "<contractAgreementId>",
-       "submodels": [
-        {
-            "identification": "<identification>>",
-            "aspectType": "<aspectType>",
-            "payload": {
-              <... submodel payload ...>
-        }
-      ] 
-    }     
-        
-  ]
+"submodels": [
+  {
+    "identification": "urn:uuid:f9b6f066-c4de-4bed-b531-2a1cad7bd173",
+    "aspectType": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
+    "contractAgreementId": "<contractAgreementId>",
+    "payload": {
+      <... submodel payload ...>
+    }
+  }
+]
 ```
 
-### <ins>Add Tombstone in case of not matching policy</ins> 
+#### Option 2: Provide submodel for contractAgreementId
+
+Impact:
+
+1. High invasive changes to the code, api, JobResponse and documentation.
+2. This variant complicates the optional (activatable/deactivatable) collection of ContractAggreementIds as these are an
+   essential part of the response structure.
+
+```json 
+"contractAggreements": [
+  "contractAggreement": {
+    "contractAgreementId": "<contractAgreementId>",
+    "submodels": [
+       {
+         "identification": "<identification>>",
+         "aspectType": "<aspectType>",
+         "payload": {
+           <... submodel payload ...>
+         }
+       }
+    ] 
+  }
+]
+```
+
+### Add Tombstone in case of not matching policy
 
 Tombstone is extended with policy payload when policy is not matched and contract negotiation is not conducted.
-The requestor gets the insight which policy does not match and has the opportunity to add the specific policy to the IRS policy store in order to receice further on assets with the specific policy. 
+The requestor gets the insight which policy does not match and has the opportunity to add the specific policy to the IRS
+policy store in order to receice further on assets with the specific policy.
 
-- [ ] Tombstone is extended with policy payload in case policy is invalid AND auditContractNegotiation api parameter is enabled.  
+- [ ] Tombstone is extended with policy payload in case policy is invalid AND auditContractNegotiation api parameter is
+  enabled.
 
 `````json 
 "tombstones": [
-    {
-      "catenaXId": "urn:uuid:6ce41c0b-c84a-46b0-b4c4-78fce958663d", 
-      "endpointURL": null,
-      "policy": {
-            "odrl:hasPolicy": {
-                "@id": "ZDgzZjhjY2EtMGY2MC00OWMzLWJjNDYtMWE0OTY2MDdlMzhj:cmVnaXN0cnktYXNzZXQ=:Y2IxNzI5MjUtYzUyNS00NmJiLWFiZWQtMDVhMTdkNTFiZTg0",
-                "@type": "odrl:Set",
-                "odrl:permission": {
-                  "odrl:target": "registry-asset",
-                  "odrl:action": {
-                      "odrl:type": "USE"
-                  },
-                  "odrl:constraint": {
-                      "odrl:or": {
-                      "odrl:leftOperand": "PURPOSE",
-                      "odrl:operator": {
-                      "@id": "odrl:eq"
-                  },
-                    "odrl:rightOperand": "ID 3.0 Trace"
-                  }
-              }
-         }
-      },         
-      "processingError": {
-          "processStep": "DigitalTwinRequest",
-          "errorDetail": "EndpointDataReference was not found. Requested connectorEndpoints: https://test1.doubleSlash.com, https://test2.doubleSlash.com",
-          "lastAttempt": "2024-01-17T09:02:36.648055745Z",
-          "retryCounter": 3
+  {
+    "catenaXId": "urn:uuid:6ce41c0b-c84a-46b0-b4c4-78fce958663d",
+    "endpointURL": null,
+    "policy": {
+      "odrl:hasPolicy": {
+      "@id": "ZDgzZjhjY2EtMGY2MC00OWMzLWJjNDYtMWE0OTY2MDdlMzhj:cmVnaXN0cnktYXNzZXQ=:Y2IxNzI5MjUtYzUyNS00NmJiLWFiZWQtMDVhMTdkNTFiZTg0",
+      "@type": "odrl:Set",
+      "odrl:permission": {
+        "odrl:target": "registry-asset",
+        "odrl:action": {
+          "odrl:type": "USE"
+        }
+      },
+      "odrl:constraint": {
+        "odrl:or": {
+          "odrl:leftOperand": "PURPOSE",
+          "odrl:operator": {
+            "@id": "odrl:eq"
+          },
+          "odrl:rightOperand": "ID 3.0 Trace"
+        }
       }
+      }
+    },
+    "processingError": {
+      "processStep": "DigitalTwinRequest",
+      "errorDetail": "EndpointDataReference was not found. Requested connectorEndpoints: https://test1.doubleSlash.com, https://test2.doubleSlash.com",
+      "lastAttempt": "2024-01-17T09:02:36.648055745Z",
+      "retryCounter": 3
     }
+  }
 ],
-
 `````
 
-# <ins>Glossary</ins> <a name="glossary"></a>
+# Glossary
 
-| Abbreviation           | Name                    | Description                                 |  
-|------------------------|-------------------------|---------------------------------------------|
-| edc:ContractAgreement  |edc:ContractAgreement    | ContractAgreement of negotation in EDC      |
-| edc:ContractNegotation |edc:ContractNegotation   | ContractNegotation of negotation in EDC     |
-| AAS                    |AssetAdministrationShell | The Shell object dtored in  dDTR registry   | 
-| CID                    | contractAgreementId     | Unique Id of an contract aggrement          |
+| Abbreviation           | Name                     | Description                               |  
+|------------------------|--------------------------|-------------------------------------------|
+| edc:ContractAgreement  | edc:ContractAgreement    | ContractAgreement of negotation in EDC    |
+| edc:ContractNegotation | edc:ContractNegotation   | ContractNegotation of negotation in EDC   |
+| AAS                    | AssetAdministrationShell | The Shell object dtored in  dDTR registry | 
+| CID                    | contractAgreementId      | Unique Id of an contract aggrement        |
 
-# <ins>References</ins> <a name="references"></a>
+# References
 
 https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.3#/Contract%20Agreement/getAgreementById
 https://github.com/eclipse-tractusx/tractusx-edc/blob/main/docs/kit/Development%20View/01_MGMT_API_Walkthrough/02_policies.md

--- a/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
+++ b/docs/concept/#322-Provisioning-of-contractAgreementId-for-assets/#322-Provisioning-of-contractAgreementId-for-assets.md
@@ -43,8 +43,7 @@ circumstance is reported in a tombstone which contains the policy of the asset.
 
 1. The ContractAgreementDto:@id is currently not delivered via the IRS response, so business apps that use the IRS
    cannot access the corresponding ContractAggreement under which the assets, delivered by the IRS, were exchanged.
-2. Teh EDC management API provides a endpoint ro query contract agreement by assetId. It is not possible to determine
-   which ContractAggreement belongs to which negotiation in case of multiple negotiations for the same asset
+2. The EDC management API provides an endpoint to query contract agreements by assetId. It is not possible to determine which ContractAgreement belongs to which negotiation in case of multiple negotiations for the same asset
 3. Business apps must make the contract agreements under which the assets were exchanged available for audit purposes.
 
 # Requirements

--- a/docs/concept/TEMPLATE_Concept.md
+++ b/docs/concept/TEMPLATE_Concept.md
@@ -15,6 +15,7 @@
 6. [Out of scope](#outofscope)
 7. [Concept](#concept)
 8. [Glossary](#glossary)
+9. [References](#references)
 
 
 # <ins>Overview</ins> <a name="overview"></a>
@@ -38,3 +39,5 @@
 |-------------|-----------------------------|
 |   |  |
 |   |  |
+
+# <ins>References</ins> <a name="references"></a>

--- a/docs/concept/TEMPLATE_Concept.md
+++ b/docs/concept/TEMPLATE_Concept.md
@@ -13,9 +13,10 @@
 4. [Requirements](#requirements)
 5. [NFR](#nfr)
 6. [Out of scope](#outofscope)
-7. [Concept](#concept)
-8. [Glossary](#glossary)
-9. [References](#references)
+7. [Assumptions](#assumptions)
+8. [Concept](#concept)
+9. [Glossary](#glossary)
+10. [References](#references)
 
 
 # <ins>Overview</ins> <a name="overview"></a>

--- a/docs/concept/TEMPLATE_Concept.md
+++ b/docs/concept/TEMPLATE_Concept.md
@@ -12,14 +12,15 @@
 3. [Problem Statement](#statement)
 4. [Requirements](#requirements)
 5. [NFR](#nfr)
-6. [Concept](#concept)
-7. [Glossary](#glossary)
+6. [Out of scope](#outofscope)
+7. [Concept](#concept)
+8. [Glossary](#glossary)
 
 
 # <ins>Overview</ins> <a name="overview"></a>
 
 
-# <ins>Summarny</ins> <a name="summary"></a>
+# <ins>Summary</ins> <a name="summary"></a>
 
 # <ins>Problem Statement</ins> <a name="statement"></a>
 
@@ -27,8 +28,9 @@
 
 # <ins>NFR</ins> <a name="nfr"></a>
 
-# <ins>Concept</ins> <a name="concept"></a>
+# <ins>Out of scope</ins> <a name="outofscope"></a>
 
+# <ins>Concept</ins> <a name="concept"></a>
 
 # <ins>Glossary</ins> <a name="glossary"></a>
 

--- a/docs/concept/TEMPLATE_Concept.md
+++ b/docs/concept/TEMPLATE_Concept.md
@@ -1,0 +1,38 @@
+# \[Concept\] \[#ID#\] Summary 
+
+| Key           | Value             |
+|---------------|-------------------|
+| Creation date | <DD.MM.YYYY>      |
+| Ticket Id     | <ID> <url>        |    
+| State        | <DRAFT,WIP, DONE> | 
+
+# Table of Contents
+1. [Overview](#overview)
+2. [Summary](#summary)
+3. [Problem Statement](#statement)
+4. [Requirements](#requirements)
+5. [NFR](#nfr)
+6. [Concept](#concept)
+7. [Glossary](#glossary)
+
+
+# <ins>Overview</ins> <a name="overview"></a>
+
+
+# <ins>Summarny</ins> <a name="summary"></a>
+
+# <ins>Problem Statement</ins> <a name="statement"></a>
+
+# <ins>Requirements</ins> <a name="requirements"></a>
+
+# <ins>NFR</ins> <a name="nfr"></a>
+
+# <ins>Concept</ins> <a name="concept"></a>
+
+
+# <ins>Glossary</ins> <a name="glossary"></a>
+
+| Abbreviation | Name                        |
+|-------------|-----------------------------|
+|   |  |
+|   |  |

--- a/docs/concept/TEMPLATE_Concept.md
+++ b/docs/concept/TEMPLATE_Concept.md
@@ -1,44 +1,45 @@
-# \[Concept\] \[#ID#\] Summary 
+# \[Concept\] \[#ID#\] Summary
 
 | Key           | Value             |
 |---------------|-------------------|
 | Creation date | <DD.MM.YYYY>      |
 | Ticket Id     | <ID> <url>        |    
-| State        | <DRAFT,WIP, DONE> | 
+| State         | <DRAFT,WIP, DONE> | 
 
-# Table of Contents
+## Table of Contents
+
 1. [Overview](#overview)
 2. [Summary](#summary)
-3. [Problem Statement](#statement)
+3. [Problem Statement](#problem-statement)
 4. [Requirements](#requirements)
 5. [NFR](#nfr)
-6. [Out of scope](#outofscope)
+6. [Out of scope](#out-of-scope)
 7. [Assumptions](#assumptions)
 8. [Concept](#concept)
 9. [Glossary](#glossary)
 10. [References](#references)
 
+## Overview
 
-# <ins>Overview</ins> <a name="overview"></a>
+## Summary
 
+## Problem Statement
 
-# <ins>Summary</ins> <a name="summary"></a>
+## Requirements
 
-# <ins>Problem Statement</ins> <a name="statement"></a>
+## NFR
 
-# <ins>Requirements</ins> <a name="requirements"></a>
+## Out of scope
 
-# <ins>NFR</ins> <a name="nfr"></a>
+## Assumptions
 
-# <ins>Out of scope</ins> <a name="outofscope"></a>
+## Concept
 
-# <ins>Concept</ins> <a name="concept"></a>
+## Glossary
 
-# <ins>Glossary</ins> <a name="glossary"></a>
+| Abbreviation | Name |
+|--------------|------|
+|              |      |
+|              |      |
 
-| Abbreviation | Name                        |
-|-------------|-----------------------------|
-|   |  |
-|   |  |
-
-# <ins>References</ins> <a name="references"></a>
+## References


### PR DESCRIPTION
Provisioning of required identifications for contract negation and contract agreement id edc:ContractAgreementDto@id
 IRS provides the ContractAgreeementId for data asset in JobResponse on demand
 How the business app can request the edc:ContractAgreement and ContractNegotation Payload to visualize the required results
 Specify the time period the ContractAgreeementId payload and ContractNegotation payload should be accessible and be available for the business app - according to that decide if information should be stored in IRS or stored in the EDC. How long does the EDC store this information and is it sufficient to store this in the EDC - (10 years according to law)