### PR TITLE
chore(workflows): Skip checkstyle and PMD for sonar scan

### DIFF
--- a/.github/workflows/irs-build.yml
+++ b/.github/workflows/irs-build.yml
@@ -80,7 +80,8 @@ jobs:
         run: |
           mvn --batch-mode --update-snapshots verify \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-          -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }} -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
+          -Dsonar.projectKey=${SONAR_PROJECT_KEY} -Dsonar.organization=${SONAR_ORGANIZATION} \
+          -Dcheckstyle.skip -Dpmd.skip=true
 
   build_images:
     strategy:

--- a/.github/workflows/irs-build.yml
+++ b/.github/workflows/irs-build.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           mvn --batch-mode --update-snapshots verify \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-          -Dsonar.projectKey=${SONAR_PROJECT_KEY} -Dsonar.organization=${SONAR_ORGANIZATION} \
+          -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }} -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }} \
           -Dcheckstyle.skip -Dpmd.skip=true
 
   build_images:


### PR DESCRIPTION
Skip checkstyle and PMD for sonar scan since this is already checked by the irs build job. 
By skipping these checks, Sonar results will be published even if the checks fail which results in a faster feedback loop for developers