### PR TITLE
chore(foss):[#349] Also update the detailed copyright section

### DIFF
--- a/.config/irs.header
+++ b/.config/irs.header
@@ -1,8 +1,8 @@
 ^/\*\*{79}$
-^ \* Copyright \(c\) 2021,2022,2023$
+^ \* Copyright \(c\) 2022,2024$
 ^ \*       2022: ZF Friedrichshafen AG$
 ^ \*       2022: ISTOS GmbH$
-^ \*       2022,2023: Bayerische Motoren Werke Aktiengesellschaft \(BMW AG\)$
+^ \*       2022,2024: Bayerische Motoren Werke Aktiengesellschaft \(BMW AG\)$
 ^ \*       2022,2023: BOSCH AG$
 ^ \* Copyright \(c\) 2021,2024 Contributors to the Eclipse Foundation$
 ^ \*$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/.helmignore
+++ b/charts/irs-helm/.helmignore
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/Chart.yaml
+++ b/charts/irs-helm/Chart.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/_helpers.tpl
+++ b/charts/irs-helm/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{/*
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/charts/irs-helm/templates/configmap-grafana-dashboards.yaml
+++ b/charts/irs-helm/templates/configmap-grafana-dashboards.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/configmap-semantic-models.yaml
+++ b/charts/irs-helm/templates/configmap-semantic-models.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/configmap-spring-app-config.yaml
+++ b/charts/irs-helm/templates/configmap-spring-app-config.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/deployment.yaml
+++ b/charts/irs-helm/templates/deployment.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/ingress.yaml
+++ b/charts/irs-helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/secrets.yaml
+++ b/charts/irs-helm/templates/secrets.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/service.yaml
+++ b/charts/irs-helm/templates/service.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/templates/tests/test-connection.yaml
+++ b/charts/irs-helm/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/charts/irs-helm/values.yaml
+++ b/charts/irs-helm/values.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
 #       2022: ZF Friedrichshafen AG
 #       2022: ISTOS GmbH
-#       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/docs/src/diagram-replacer/extract.js
+++ b/docs/src/diagram-replacer/extract.js
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/docs/src/diagram-replacer/replace.js
+++ b/docs/src/diagram-replacer/replace.js
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/docs/src/post-processing/fix_headers.js
+++ b/docs/src/post-processing/fix_headers.js
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/docs/src/post-processing/fix_https_links.js
+++ b/docs/src/post-processing/fix_https_links.js
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/docs/src/post-processing/fix_no_emphasis.js
+++ b/docs/src/post-processing/fix_no_emphasis.js
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/docs/src/post-processing/fix_relative_links.js
+++ b/docs/src/post-processing/fix_relative_links.js
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/IrsApplication.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/IrsApplication.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASRecursiveJobHandler.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASRecursiveJobHandler.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcess.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcess.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/CallbackResponderEventListener.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/CallbackResponderEventListener.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ExtractDataFromProtocolInformation.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ExtractDataFromProtocolInformation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ItemContainer.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ItemContainer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ItemDataRequest.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ItemDataRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ItemTreesAssembler.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/ItemTreesAssembler.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/RequestMetric.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/RequestMetric.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/TreeRecursiveLogic.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/TreeRecursiveLogic.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/AbstractDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/AbstractDelegate.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegate.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateProcessingException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateProcessingException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/DigitalTwinDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/DigitalTwinDelegate.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/RelationshipDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/RelationshipDelegate.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegate.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegate.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/BpdmClient.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/BpdmClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/BpdmFacade.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/BpdmFacade.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/BusinessPartnerResponse.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/BusinessPartnerResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/NameResponse.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/bpdm/NameResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/BlobstoreConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/BlobstoreConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthIndicator.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthIndicator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthMetricsExportConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthMetricsExportConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/HealthMetricsExportConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/HealthMetricsExportConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/HealthStatusHelper.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/HealthStatusHelper.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/IrsConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/IrsConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/JobConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/MinioHealthIndicator.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/MinioHealthIndicator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/OpenApiConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/OpenApiConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/OpenApiExamples.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/OpenApiExamples.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RegistryConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RegistryConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RestTemplateConfig.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RestTemplateConfig.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/SemanticsHubConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/SemanticsHubConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/TrustedEndpointsFilter.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/TrustedEndpointsFilter.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/TrustedPortConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/TrustedPortConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeyAuthentication.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeyAuthentication.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeyAuthenticationFilter.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeyAuthenticationFilter.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeyAuthority.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeyAuthority.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeysConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/ApiKeysConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/AuthenticationService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/AuthenticationService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/SecurityConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/security/SecurityConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/Batch.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/Batch.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/BatchOrder.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/BatchOrder.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/BatchOrderStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/BatchOrderStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/BatchStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/BatchStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/InMemoryBatchOrderStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/InMemoryBatchOrderStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/InMemoryBatchStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/InMemoryBatchStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/JobProgress.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/JobProgress.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchOrderStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchOrderStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/DataRequest.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/DataRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/InMemoryJobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/InMemoryJobStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/IrsTimer.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/IrsTimer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/IrsTimerAspect.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/IrsTimerAspect.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobInitiateResponse.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobInitiateResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobOrchestrator.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobOrchestrator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobTTL.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobTTL.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/MultiTransferJob.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/MultiTransferJob.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/PersistentJobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/PersistentJobStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/RecursiveJobHandler.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/RecursiveJobHandler.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/ResponseStatus.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/ResponseStatus.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferInitiateResponse.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferInitiateResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcess.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcess.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcessManager.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/BatchController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/BatchController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsAppConstants.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsAppConstants.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsExceptionHandler.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsExceptionHandler.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/AspectTypeNotFoundException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/AspectTypeNotFoundException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/BPNIncidentValidation.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/BPNIncidentValidation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/IncidentValidation.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/IncidentValidation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/InvalidAspectTypeFormatException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/InvalidAspectTypeFormatException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/InvestigationResult.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/InvestigationResult.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/ValidationException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/bpn/validation/ValidationException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/EssController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/EssController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
@@ -40,12 +40,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.tractusx.irs.ess.service.EssService;
 import org.eclipse.tractusx.irs.common.auth.IrsRoles;
 import org.eclipse.tractusx.irs.component.JobHandle;
 import org.eclipse.tractusx.irs.component.Jobs;
 import org.eclipse.tractusx.irs.component.RegisterBpnInvestigationJob;
 import org.eclipse.tractusx.irs.dtos.ErrorResponse;
+import org.eclipse.tractusx.irs.ess.service.EssService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/EssRecursiveController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/EssRecursiveController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/NotificationReceiverController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/NotificationReceiverController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/mock/MockedNotificationReceiverController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/mock/MockedNotificationReceiverController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/discovery/EdcDiscoveryMockConfig.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/discovery/EdcDiscoveryMockConfig.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/BpnInvestigationJob.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/BpnInvestigationJob.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/BpnInvestigationJobCache.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/BpnInvestigationJobCache.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EdcNotificationSender.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EdcNotificationSender.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EdcRegistration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EdcRegistration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveNotificationHandler.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveNotificationHandler.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EssService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/EssService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/InvestigationJobProcessingEventListener.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/InvestigationJobProcessingEventListener.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/NotificationSummary.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/NotificationSummary.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/RelatedInvestigationJobs.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/RelatedInvestigationJobs.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/RelatedInvestigationJobsCache.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/RelatedInvestigationJobsCache.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/SupplyChainImpacted.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/SupplyChainImpacted.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/SupplyChainImpactedAspect.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/service/SupplyChainImpactedAspect.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/AspectModel.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/AspectModel.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/AspectModels.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/AspectModels.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/PaginatedResponse.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/PaginatedResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubCacheInitializer.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubCacheInitializer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubClient.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubFacade.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubFacade.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/BatchOrderEventListener.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/BatchOrderEventListener.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/CreationBatchService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/CreationBatchService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/IIrsItemGraphQueryService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/IIrsItemGraphQueryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/JobEventLinkedQueueListener.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/JobEventLinkedQueueListener.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/MeterRegistryService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/MeterRegistryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/QueryBatchService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/QueryBatchService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/SemanticHubService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/SemanticHubService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/events/BatchOrderProcessingFinishedEvent.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/events/BatchOrderProcessingFinishedEvent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/events/BatchOrderRegisteredEvent.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/events/BatchOrderRegisteredEvent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/events/BatchProcessingFinishedEvent.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/events/BatchProcessingFinishedEvent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/timeouts/CancelBatchProcessingService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/timeouts/CancelBatchProcessingService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/timeouts/TimeoutSchedulerBatchProcessingService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/timeouts/TimeoutSchedulerBatchProcessingService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/InvalidSchemaException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/InvalidSchemaException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/JsonValidatorService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/JsonValidatorService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/SchemaNotFoundException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/SchemaNotFoundException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/ValidationResult.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/validation/ValidationResult.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomUriTagProvider.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomUriTagProvider.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/JobMetrics.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/JobMetrics.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/JsonUtil.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/JsonUtil.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ConnectorEndpointServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ConnectorEndpointServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ControllerTest.java
@@ -1,10 +1,10 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
- * Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/DiscoveryFinderClientTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/DiscoveryFinderClientTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/InMemoryBlobStore.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/InMemoryBlobStore.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/IrsApplicationTests.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/IrsApplicationTests.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/IrsFunctionalTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/IrsFunctionalTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/TestConfig.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/TestConfig.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManagerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManagerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/AbstractDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/AbstractDelegateTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/DigitalTwinDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/DigitalTwinDelegateTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/RelationshipDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/RelationshipDelegateTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/SubmodelDelegateTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/bpdm/BpdmClientImplTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/bpdm/BpdmClientImplTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/bpdm/BpdmFacadeTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/bpdm/BpdmFacadeTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/component/tombstone/TombStoneTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/component/tombstone/TombStoneTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthIndicatorTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthIndicatorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthMetricsExportConfigurationTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/DependenciesHealthMetricsExportConfigurationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/HealthMetricsExportConfigurationTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/HealthMetricsExportConfigurationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/HealthStatusHelperTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/HealthStatusHelperTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/MinioHealthIndicatorTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/MinioHealthIndicatorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/TrustedEndpointsFilterTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/TrustedEndpointsFilterTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/TrustedPortConfigurationTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/TrustedPortConfigurationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/security/AuthenticationServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/configuration/security/AuthenticationServiceTest.java
@@ -1,10 +1,10 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
- * Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchOrderStoreTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchOrderStoreTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchStoreTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/batch/PersistentBatchStoreTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/InMemoryJobStoreTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/InMemoryJobStoreTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/JobOrchestratorTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/JobOrchestratorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/MultiTransferJobTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/MultiTransferJobTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/PersistentJobStoreTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/connector/job/PersistentJobStoreTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/BatchControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/BatchControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/IrsControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/IrsControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/IrsExceptionHandlerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/IrsExceptionHandlerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/dto/assetadministrationshell/AssetAdministrationShellDescriptorTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/dto/assetadministrationshell/AssetAdministrationShellDescriptorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/bpn/validation/BPNIncidentValidationTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/bpn/validation/BPNIncidentValidationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/EssControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/EssControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/EssRecursiveControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/EssRecursiveControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/NotificationReceiverControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/NotificationReceiverControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/mock/MockedNotificationReceiverControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/controller/mock/MockedNotificationReceiverControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EdcNotificationSenderTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EdcNotificationSenderTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EdcRegistrationTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EdcRegistrationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveNotificationHandlerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveNotificationHandlerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EssRecursiveServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EssServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/EssServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/InvestigationJobProcessingEventListenerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/ess/service/InvestigationJobProcessingEventListenerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticHubCacheInitializerTests.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticHubCacheInitializerTests.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticHubWiremockTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticHubWiremockTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubClientImplTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubClientImplTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubFacadeTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubFacadeTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/BatchOrderEventListenerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/BatchOrderEventListenerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/CreationBatchServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/CreationBatchServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceSpringBootTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceSpringBootTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/JobEventLinkedQueueListenerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/JobEventLinkedQueueListenerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/MeterRegistryServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/MeterRegistryServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/QueryBatchServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/QueryBatchServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/timeouts/CancelBatchProcessingServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/timeouts/CancelBatchProcessingServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/timeouts/TimeoutSchedulerBatchProcessingServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/timeouts/TimeoutSchedulerBatchProcessingServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/validation/JsonValidatorServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/validation/JsonValidatorServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/util/JobResponseAnalyzerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/util/JobResponseAnalyzerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/util/JsonUtilTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/util/JsonUtilTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/util/Mod10ValidatorTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/util/Mod10ValidatorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/util/StringMapperTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/util/StringMapperTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/util/TestMother.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/util/TestMother.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/ApiConstants.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/ApiConstants.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/JobProcessingFinishedEvent.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/JobProcessingFinishedEvent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/OutboundMeterRegistryService.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/OutboundMeterRegistryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/auth/IrsRoles.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/auth/IrsRoles.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/auth/SecurityHelperService.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/auth/SecurityHelperService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/persistence/BlobPersistence.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/persistence/BlobPersistence.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/persistence/BlobPersistenceException.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/persistence/BlobPersistenceException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/main/java/org/eclipse/tractusx/irs/common/persistence/MinioBlobPersistence.java
+++ b/irs-common/src/main/java/org/eclipse/tractusx/irs/common/persistence/MinioBlobPersistence.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/test/java/org/eclipse/tractusx/irs/common/OutboundMeterRegistryServiceTest.java
+++ b/irs-common/src/test/java/org/eclipse/tractusx/irs/common/OutboundMeterRegistryServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/test/java/org/eclipse/tractusx/irs/common/auth/SecurityHelperServiceTest.java
+++ b/irs-common/src/test/java/org/eclipse/tractusx/irs/common/auth/SecurityHelperServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-common/src/test/java/org/eclipse/tractusx/irs/common/persistence/MinioBlobPersistenceTest.java
+++ b/irs-common/src/test/java/org/eclipse/tractusx/irs/common/persistence/MinioBlobPersistenceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-cucumber-tests/src/test/java/org/eclipse/tractusx/irs/cucumber/AuthenticationProperties.java
+++ b/irs-cucumber-tests/src/test/java/org/eclipse/tractusx/irs/cucumber/AuthenticationProperties.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-cucumber-tests/src/test/java/org/eclipse/tractusx/irs/cucumber/E2ETestStepDefinitions.java
+++ b/irs-cucumber-tests/src/test/java/org/eclipse/tractusx/irs/cucumber/E2ETestStepDefinitions.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/AsyncPollingService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/AsyncPollingService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/ContractNegotiationService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/ContractNegotiationService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EDCCatalogFacade.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EDCCatalogFacade.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackController.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcConfiguration.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcControlPlaneClient.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcControlPlaneClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcDataPlaneClient.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcDataPlaneClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClient.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientImpl.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientImpl.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientLocalStub.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientLocalStub.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacade.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacade.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EndpointDataReferenceStorage.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/EndpointDataReferenceStorage.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/ItemNotFoundInCatalogException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/ItemNotFoundInCatalogException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/PollingJob.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/PollingJob.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/RelationshipAspect.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/RelationshipAspect.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/RelationshipSubmodel.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/RelationshipSubmodel.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/RunnableDecorator.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/RunnableDecorator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelBomAsBuilt.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelBomAsBuilt.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelBomAsPlanned.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelBomAsPlanned.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelBomAsSpecified.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelBomAsSpecified.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelUsageAsBuilt.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SingleLevelUsageAsBuilt.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SubmodelTestdataCreator.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/SubmodelTestdataCreator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/cache/endpointdatareference/EndpointDataReferenceCacheService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/cache/endpointdatareference/EndpointDataReferenceCacheService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/cache/endpointdatareference/EndpointDataReferenceStatus.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/cache/endpointdatareference/EndpointDataReferenceStatus.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/configuration/JsonLdConfiguration.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/configuration/JsonLdConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/ContractNegotiationException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/ContractNegotiationException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/EdcClientException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/EdcClientException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/TimeoutException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/TimeoutException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/TransferProcessException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/TransferProcessException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/UsagePolicyException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/exceptions/UsagePolicyException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/CatalogItem.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/CatalogItem.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/CatalogRequest.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/CatalogRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/ContractOfferDescription.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/ContractOfferDescription.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/ContractOfferInCatalogResponse.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/ContractOfferInCatalogResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/ContractOfferRequest.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/ContractOfferRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/EDRAuthCode.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/EDRAuthCode.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/NegotiationRequest.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/NegotiationRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/NegotiationResponse.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/NegotiationResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/NegotiationState.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/NegotiationState.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/Response.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/Response.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/TransferProcessDataDestination.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/TransferProcessDataDestination.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/TransferProcessRequest.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/TransferProcessRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/TransferProcessResponse.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/TransferProcessResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/EdcNotification.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/EdcNotification.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/EdcNotificationHeader.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/EdcNotificationHeader.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/EdcNotificationResponse.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/EdcNotificationResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/InvestigationNotificationContent.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/InvestigationNotificationContent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/NotificationContent.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/NotificationContent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/ResponseNotificationContent.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/model/notification/ResponseNotificationContent.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/AcceptedPoliciesProvider.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/AcceptedPoliciesProvider.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/AcceptedPolicy.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/AcceptedPolicy.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/AtomicConstraintValidator.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/AtomicConstraintValidator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraint.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraint.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/ConstraintCheckerService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/ConstraintCheckerService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraints.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraints.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/OperatorType.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/OperatorType.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Permission.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Permission.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Policy.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Policy.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyCheckerService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyCheckerService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyDefinition.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyDefinition.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyType.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyType.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/EdcTransformer.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/EdcTransformer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromCatalogRequestTransformer.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromCatalogRequestTransformer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromContractOfferDescriptionTransformer.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromContractOfferDescriptionTransformer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromNegotiationInitiateDtoTransformer.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromNegotiationInitiateDtoTransformer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromTransferProcessRequestTransformer.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/JsonObjectFromTransferProcessRequestTransformer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/util/Masker.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/util/Masker.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/ContractNegotiationServiceTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/ContractNegotiationServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/CxTestDataAnalyzerTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/CxTestDataAnalyzerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EDCCatalogFacadeTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EDCCatalogFacadeTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackControllerTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcCallbackControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcControlPlaneClientTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcControlPlaneClientTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcDataPlaneClientTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcDataPlaneClientTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientLocalStubTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientLocalStubTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelClientTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacadeTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/EdcSubmodelFacadeTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/RelationshipAspectTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/RelationshipAspectTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelFacadeWiremockTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelFacadeWiremockTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelTestdataCreatorTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/SubmodelTestdataCreatorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/configuration/JsonLdConfigurationTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/configuration/JsonLdConfigurationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/AcceptedPoliciesProviderTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/AcceptedPoliciesProviderTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/ConstraintCheckerServiceTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/ConstraintCheckerServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyCheckerServiceTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/PolicyCheckerServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/testutil/TestConstants.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/testutil/TestConstants.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/testutil/TestMother.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/testutil/TestMother.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/transformer/EdcTransformerTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/transformer/EdcTransformerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/util/EndpointDataReferenceCacheServiceTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/util/EndpointDataReferenceCacheServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/util/MaskerTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/util/MaskerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestConfiguration.java
+++ b/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestConnectionProperties.java
+++ b/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestConnectionProperties.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestCredentialsProperties.java
+++ b/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/configuration/SmokeTestCredentialsProperties.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/smoketest/ItemGraphSmokeTest.java
+++ b/irs-integration-tests/src/test/java/org/eclipse/tractusx/irs/smoketest/ItemGraphSmokeTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/AsyncFetchedItems.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/AsyncFetchedItems.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/BatchOrderCreated.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/BatchOrderCreated.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/BatchOrderResponse.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/BatchOrderResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/BatchResponse.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/BatchResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Bpn.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Bpn.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Description.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Description.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Endpoint.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Endpoint.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/FetchedItems.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/FetchedItems.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/GenericDescription.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/GenericDescription.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/GlobalAssetIdentification.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/GlobalAssetIdentification.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/IStatusCodeEnum.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/IStatusCodeEnum.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Job.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Job.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobErrorDetails.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobErrorDetails.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobHandle.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobHandle.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobParameter.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobParameter.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobStatusResult.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/JobStatusResult.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Jobs.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Jobs.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/LinkedItem.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/LinkedItem.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/MeasurementUnit.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/MeasurementUnit.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Notification.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Notification.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/PageResult.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/PageResult.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/PartChainIdentificationKey.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/PartChainIdentificationKey.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/ProcessingError.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/ProcessingError.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/ProtocolInformation.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/ProtocolInformation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Quantity.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Quantity.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterBatchOrder.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterBatchOrder.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterBpnInvestigationBatchOrder.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterBpnInvestigationBatchOrder.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterBpnInvestigationJob.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterBpnInvestigationJob.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterJob.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/RegisterJob.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Relationship.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Relationship.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/SemanticId.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/SemanticId.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Shell.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Shell.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Submodel.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Submodel.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/SubmodelDescriptor.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/SubmodelDescriptor.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Summary.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Summary.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Tombstone.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/Tombstone.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/AdministrativeInformation.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/AdministrativeInformation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/AssetAdministrationShellDescriptor.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/AssetAdministrationShellDescriptor.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/Endpoint.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/Endpoint.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/IdentifierKeyValuePair.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/IdentifierKeyValuePair.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/LangString.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/LangString.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/ProtocolInformation.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/ProtocolInformation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/Reference.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/Reference.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/SemanticId.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/SemanticId.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/SubmodelDescriptor.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/assetadministrationshell/SubmodelDescriptor.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/AspectType.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/AspectType.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/BatchStrategy.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/BatchStrategy.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/BomLifecycle.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/BomLifecycle.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/Direction.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/Direction.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/JobState.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/JobState.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/NodeType.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/NodeType.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/ProcessStep.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/ProcessStep.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/ProcessingState.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/ProcessingState.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/StatusCodeEnum.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/enums/StatusCodeEnum.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partasplanned/PartAsPlanned.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partasplanned/PartAsPlanned.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partasplanned/PartTypeInformation.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partasplanned/PartTypeInformation.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partasplanned/ValidityPeriod.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partasplanned/ValidityPeriod.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partsiteinformationasplanned/PartSiteInformationAsPlanned.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partsiteinformationasplanned/PartSiteInformationAsPlanned.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partsiteinformationasplanned/Site.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/component/partsiteinformationasplanned/Site.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/data/CxTestDataContainer.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/data/CxTestDataContainer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/data/JsonParseException.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/data/JsonParseException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/data/LocalTestDataConfiguration.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/data/LocalTestDataConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/data/StringMapper.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/data/StringMapper.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/dtos/ErrorResponse.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/dtos/ErrorResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/validators/Mod10.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/validators/Mod10.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-models/src/main/java/org/eclipse/tractusx/irs/validators/Mod10Validator.java
+++ b/irs-models/src/main/java/org/eclipse/tractusx/irs/validators/Mod10Validator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/DefaultAcceptedPoliciesConfig.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/DefaultAcceptedPoliciesConfig.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/PolicyBlobstoreConfiguration.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/PolicyBlobstoreConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/PolicyConfiguration.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/PolicyConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreController.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreController.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/exceptions/PolicyStoreException.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/exceptions/PolicyStoreException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/models/CreatePolicyRequest.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/models/CreatePolicyRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/models/UpdatePolicyRequest.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/models/UpdatePolicyRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/persistence/PolicyPersistence.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/persistence/PolicyPersistence.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreService.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/test/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreControllerTest.java
+++ b/irs-policy-store/src/test/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreControllerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/test/java/org/eclipse/tractusx/irs/policystore/persistence/PolicyPersistenceTest.java
+++ b/irs-policy-store/src/test/java/org/eclipse/tractusx/irs/policystore/persistence/PolicyPersistenceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-policy-store/src/test/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreServiceTest.java
+++ b/irs-policy-store/src/test/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DefaultConfiguration.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DefaultConfiguration.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryKey.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryKey.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DigitalTwinRegistryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/AssetAdministrationShellTestdataCreator.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/AssetAdministrationShellTestdataCreator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/CentralDigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/CentralDigitalTwinRegistryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClient.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientImpl.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientImpl.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientLocalStub.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientLocalStub.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryClient.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/EdcEndpointReferenceRetriever.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/EdcEndpointReferenceRetriever.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/EdcRetrieverException.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/EdcRetrieverException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/EndpointDataForConnectorsService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/EndpointDataForConnectorsService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/LookupShellsResponse.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/decentral/LookupShellsResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsService.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryEndpoint.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryEndpoint.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClient.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClient.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClientImpl.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClientImpl.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderRequest.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderRequest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryResponse.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryResponse.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/EdcDiscoveryResult.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/EdcDiscoveryResult.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/LocalDataDiscovery.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/LocalDataDiscovery.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/exceptions/RegistryServiceException.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/exceptions/RegistryServiceException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/exceptions/ShellNotFoundException.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/exceptions/ShellNotFoundException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/DefaultConfigurationTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/DefaultConfigurationTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/AssetAdministrationShellTestdataCreatorTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/AssetAdministrationShellTestdataCreatorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/CentralDigitalTwinRegistryServiceTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/CentralDigitalTwinRegistryServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientImplTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryClientImplTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryExponentialRetryTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/central/DigitalTwinRegistryExponentialRetryTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryServiceTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/decentral/EndpointDataForConnectorsServiceTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/decentral/EndpointDataForConnectorsServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsServiceTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsServiceTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClientImplTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClientImplTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/LocalDataDiscoveryTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/LocalDataDiscoveryTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/exceptions/ShellNotFoundExceptionTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/exceptions/ShellNotFoundExceptionTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegrityAspectCreator.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegrityAspectCreator.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegrityAspectException.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegrityAspectException.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegritySigner.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegritySigner.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/KeyUtils.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/KeyUtils.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/TestdataTransformer.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/TestdataTransformer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/IntegrityAspect.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/IntegrityAspect.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/IntegrityChildPart.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/IntegrityChildPart.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/IntegrityReference.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/IntegrityReference.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/SingleLevelBomAsBuiltPayload.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/SingleLevelBomAsBuiltPayload.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/TestdataContainer.java
+++ b/irs-testdata-upload/src/main/java/org/eclipse/tractusx/irs/testing/dataintegrity/models/TestdataContainer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/test/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegrityAspectCreatorTest.java
+++ b/irs-testdata-upload/src/test/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegrityAspectCreatorTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testdata-upload/src/test/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegritySignerTest.java
+++ b/irs-testdata-upload/src/test/java/org/eclipse/tractusx/irs/testing/dataintegrity/IntegritySignerTest.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testing/src/main/java/org/eclipse/tractusx/irs/testing/containers/LocalTestDataConfigurationAware.java
+++ b/irs-testing/src/main/java/org/eclipse/tractusx/irs/testing/containers/LocalTestDataConfigurationAware.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/irs-testing/src/main/java/org/eclipse/tractusx/irs/testing/containers/MinioContainer.java
+++ b/irs-testing/src/main/java/org/eclipse/tractusx/irs/testing/containers/MinioContainer.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2021,2022,2023
+ * Copyright (c) 2022,2024
  *       2022: ZF Friedrichshafen AG
  *       2022: ISTOS GmbH
- *       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       2022,2023: BOSCH AG
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *

--- a/local/demo/ess-demo.py
+++ b/local/demo/ess-demo.py
@@ -1,7 +1,7 @@
-#  Copyright (c) 2021,2022,2023
+#  Copyright (c) 2022,2024
 #        2022: ZF Friedrichshafen AG
 #        2022: ISTOS GmbH
-#        2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#        2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #        2022,2023: BOSCH AG
 #  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #

--- a/local/deployment/full-irs/subcharts/discovery/templates/configmap.yaml
+++ b/local/deployment/full-irs/subcharts/discovery/templates/configmap.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
   #       2022: ZF Friedrichshafen AG
   #       2022: ISTOS GmbH
-  #       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
   #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
   #

--- a/local/deployment/full-irs/subcharts/discovery/templates/deployment.yaml
+++ b/local/deployment/full-irs/subcharts/discovery/templates/deployment.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
   #       2022: ZF Friedrichshafen AG
   #       2022: ISTOS GmbH
-  #       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
   #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
   #

--- a/local/deployment/full-irs/subcharts/discovery/templates/ingress.yaml
+++ b/local/deployment/full-irs/subcharts/discovery/templates/ingress.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
   #       2022: ZF Friedrichshafen AG
   #       2022: ISTOS GmbH
-  #       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
   #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
   #

--- a/local/deployment/full-irs/subcharts/discovery/templates/service.yaml
+++ b/local/deployment/full-irs/subcharts/discovery/templates/service.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
   #       2022: ZF Friedrichshafen AG
   #       2022: ISTOS GmbH
-  #       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
   #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
   #

--- a/local/deployment/full-irs/subcharts/discovery/templates/serviceaccount.yaml
+++ b/local/deployment/full-irs/subcharts/discovery/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2021,2022,2023
+# Copyright (c) 2022,2024
   #       2022: ZF Friedrichshafen AG
   #       2022: ISTOS GmbH
-  #       2022,2023: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2022,2024: Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
   #       2022,2023: BOSCH AG
 # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
   #


### PR DESCRIPTION
Story: https://github.com/eclipse-tractusx/item-relationship-service/issues/349

This change was neither described in the acceptance criteria of story 349 nor did the TRG 7.02 require it, but this additional change was requested by the PO in the iteration session on 2024-01-24.