### PR TITLE
Fix configuration of discovery finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated license header to "Copyright (c) 2021,2024 Contributors to the Eclipse Foundation"
 - Changed lookupGlobalAssetIds to lookupShellsByBPN, which provides full object.
 - Suppressed CVE-2024-20932 from graal-sdk-21.2.0.jar because this is not applicable for IRS.
+- Updated configuration of `DISCOVERY_REST_TEMPLATE` from `ess.discovery.*` to `digitalTwinRegistry.discovery.*` and discovery finder URL from `digitalTwinRegistry.discoveryFinderUrl` to `digitalTwinRegistry.discovery.discoveryFinderUrl`
 
 ### Fixed
 - Update to Spring Boot 3.1.8. This fixes the following CVEs:

--- a/charts/irs-helm/CHANGELOG.md
+++ b/charts/irs-helm/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed configuration for discovery finder url from `digitalTwinRegistry.discoveryFinderUrl` to `discovery.discoveryFinderUrl`
 
 ## [6.13.0] - 2024-01-15
 - Update IRS version to 4.4.0

--- a/charts/irs-helm/templates/configmap-spring-app-config.yaml
+++ b/charts/irs-helm/templates/configmap-spring-app-config.yaml
@@ -75,9 +75,9 @@ data:
       lookupShellsTemplate: {{ .Values.digitalTwinRegistry.lookupShellsTemplate | default "" | quote }}
       type: {{ tpl (.Values.digitalTwinRegistry.type | default "") . | quote }}
       oAuthClientId: {{ .Values.digitalTwinRegistry.oAuthClientId | default "portal" }}
-        discovery:
-          oAuthClientId: {{ .Values.discovery.oAuthClientId | default "portal" }} # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
-          discoveryFinderUrl: {{ tpl (.Values.discovery.discoveryFinderUrl | default "") . | quote }} # The endpoint to discover EDC endpoints to a particular BPN.
+      discovery:
+        oAuthClientId: {{ .Values.discovery.oAuthClientId | default "portal" }} # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
+        discoveryFinderUrl: {{ tpl (.Values.discovery.discoveryFinderUrl | default "") . | quote }} # The endpoint to discover EDC endpoints to a particular BPN.
 
     semanticshub:
       url: {{ tpl (.Values.semanticshub.url | default "") . | quote }}

--- a/charts/irs-helm/templates/configmap-spring-app-config.yaml
+++ b/charts/irs-helm/templates/configmap-spring-app-config.yaml
@@ -71,11 +71,13 @@ data:
     digitalTwinRegistry:
       descriptorEndpoint: {{ tpl (.Values.digitalTwinRegistry.descriptorEndpoint | default "") . | quote }}
       shellLookupEndpoint: {{ tpl (.Values.digitalTwinRegistry.shellLookupEndpoint | default "") . | quote }}
-      discoveryFinderUrl: {{ tpl (.Values.digitalTwinRegistry.discoveryFinderUrl | default "") . | quote }}
       shellDescriptorTemplate: {{ .Values.digitalTwinRegistry.shellDescriptorTemplate | default "" | quote }}
       lookupShellsTemplate: {{ .Values.digitalTwinRegistry.lookupShellsTemplate | default "" | quote }}
       type: {{ tpl (.Values.digitalTwinRegistry.type | default "") . | quote }}
-      oAuthClientId: {{ .Values.discovery.oAuthClientId | default "portal" }}
+      oAuthClientId: {{ .Values.digitalTwinRegistry.oAuthClientId | default "portal" }}
+        discovery:
+          oAuthClientId: {{ .Values.discovery.oAuthClientId | default "portal" }} # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
+          discoveryFinderUrl: {{ tpl (.Values.discovery.discoveryFinderUrl | default "") . | quote }} # The endpoint to discover EDC endpoints to a particular BPN.
 
     semanticshub:
       url: {{ tpl (.Values.semanticshub.url | default "") . | quote }}

--- a/charts/irs-helm/templates/configmap-spring-app-config.yaml
+++ b/charts/irs-helm/templates/configmap-spring-app-config.yaml
@@ -75,6 +75,7 @@ data:
       shellDescriptorTemplate: {{ .Values.digitalTwinRegistry.shellDescriptorTemplate | default "" | quote }}
       lookupShellsTemplate: {{ .Values.digitalTwinRegistry.lookupShellsTemplate | default "" | quote }}
       type: {{ tpl (.Values.digitalTwinRegistry.type | default "") . | quote }}
+      oAuthClientId: {{ .Values.discovery.oAuthClientId | default "portal" }}
 
     semanticshub:
       url: {{ tpl (.Values.semanticshub.url | default "") . | quote }}

--- a/charts/irs-helm/values.yaml
+++ b/charts/irs-helm/values.yaml
@@ -127,7 +127,12 @@ digitalTwinRegistry:
     {{ tpl (.Values.digitalTwinRegistry.url | default "") . }}/lookup/shells?assetIds={assetIds}
   shellDescriptorTemplate: /shell-descriptors/{aasIdentifier}  # The path to retrieve AAS descriptors from the decentral DTR, must contain the placeholder {aasIdentifier}
   lookupShellsTemplate: /lookup/shells?assetIds={assetIds}  # The path to lookup shells from the decentral DTR, must contain the placeholder {assetIds}
+  oAuthClientId: portal
+
+discovery:
+  oAuthClientId: portal  # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
   discoveryFinderUrl:  # "https://<discovery-finder-url>
+
 semanticshub:
   url:  # https://<semantics-hub-url>
   pageSize: "100"  # Number of aspect models to retrieve per page
@@ -205,9 +210,6 @@ edc:
     cacheTTL: PT24H  # Time to live for DiscoveryFinderClient for findDiscoveryEndpoints method cache
   connectorEndpointService:
     cacheTTL: PT24H  # Time to live for ConnectorEndpointService for fetchConnectorEndpoints method cache
-
-discovery:
-  oAuthClientId: portal  # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
 
 ess:
   edc:

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RegistryConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RegistryConfiguration.java
@@ -86,14 +86,14 @@ public class RegistryConfiguration {
     @Bean
     public ConnectorEndpointsService connectorEndpointsService(
             @Qualifier(RestTemplateConfig.DTR_REST_TEMPLATE) final RestTemplate dtrRestTemplate,
-            @Value("${digitalTwinRegistry.discoveryFinderUrl:}") final String finderUrl) {
+            @Value("${digitalTwinRegistry.discovery.discoveryFinderUrl:}") final String finderUrl) {
         return new ConnectorEndpointsService(discoveryFinderClient(dtrRestTemplate, finderUrl));
     }
 
     @Bean
     public DiscoveryFinderClient discoveryFinderClient(
             @Qualifier(RestTemplateConfig.DTR_REST_TEMPLATE) final RestTemplate dtrRestTemplate,
-            @Value("${digitalTwinRegistry.discoveryFinderUrl:}") final String finderUrl) {
+            @Value("${digitalTwinRegistry.discovery.discoveryFinderUrl:}") final String finderUrl) {
         return new DiscoveryFinderClientImpl(finderUrl, dtrRestTemplate);
     }
 

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RestTemplateConfig.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RestTemplateConfig.java
@@ -130,9 +130,9 @@ public class RestTemplateConfig {
 
     @Bean(DISCOVERY_REST_TEMPLATE)
         /* package */ RestTemplate discoveryRestTemplate(final RestTemplateBuilder restTemplateBuilder,
-            @Value("${ess.discovery.timeout.read}") final Duration readTimeout,
-            @Value("${ess.discovery.timeout.connect}") final Duration connectTimeout,
-            @Value("${ess.discovery.oAuthClientId}") final String clientRegistrationId) {
+            @Value("${digitalTwinRegistry.discovery.timeout.read}") final Duration readTimeout,
+            @Value("${digitalTwinRegistry.discovery.timeout.connect}") final Duration connectTimeout,
+            @Value("${digitalTwinRegistry.discovery.oAuthClientId}") final String clientRegistrationId) {
         return oAuthRestTemplate(restTemplateBuilder, readTimeout, connectTimeout, clientRegistrationId).build();
     }
 

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RestTemplateConfig.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RestTemplateConfig.java
@@ -36,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.tractusx.irs.common.OutboundMeterRegistryService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -173,7 +172,6 @@ public class RestTemplateConfig {
     }
 
     @Bean(EDC_REST_TEMPLATE)
-    @Qualifier(EDC_REST_TEMPLATE)
         /* package */ RestTemplate edcRestTemplate(final RestTemplateBuilder restTemplateBuilder,
             @Value("${irs-edc-client.submodel.timeout.read}") final Duration readTimeout,
             @Value("${irs-edc-client.submodel.timeout.connect}") final Duration connectTimeout,

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -186,7 +186,7 @@ digitalTwinRegistry:
   shellLookupEndpoint: ${DIGITALTWINREGISTRY_SHELL_LOOKUP_URL:} # The endpoint to lookup shells from the DTR, must contain the placeholder {assetIds}
   shellDescriptorTemplate: ${DIGITALTWINREGISTRY_SHELL_DESCRIPTOR_TEMPLATE:/shell-descriptors/{aasIdentifier}} # The path to retrieve AAS descriptors from the decentral DTR, must contain the placeholder {aasIdentifier}
   lookupShellsTemplate: ${DIGITALTWINREGISTRY_QUERY_SHELLS_PATH:/lookup/shells?assetIds={assetIds}} # The path to lookup shells from the decentral DTR, must contain the placeholder {assetIds}
-  oAuthClientId: common # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
+  oAuthClientId: portal # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
   discoveryFinderUrl: ${DIGITALTWINREGISTRY_DISCOVERY_FINDER_URL:} # The endpoint to discover EDC endpoints to a particular BPN.
   timeout:
     read: PT90S # HTTP read timeout for the digital twin registry client

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -187,10 +187,15 @@ digitalTwinRegistry:
   shellDescriptorTemplate: ${DIGITALTWINREGISTRY_SHELL_DESCRIPTOR_TEMPLATE:/shell-descriptors/{aasIdentifier}} # The path to retrieve AAS descriptors from the decentral DTR, must contain the placeholder {aasIdentifier}
   lookupShellsTemplate: ${DIGITALTWINREGISTRY_QUERY_SHELLS_PATH:/lookup/shells?assetIds={assetIds}} # The path to lookup shells from the decentral DTR, must contain the placeholder {assetIds}
   oAuthClientId: portal # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
-  discoveryFinderUrl: ${DIGITALTWINREGISTRY_DISCOVERY_FINDER_URL:} # The endpoint to discover EDC endpoints to a particular BPN.
   timeout:
     read: PT90S # HTTP read timeout for the digital twin registry client
     connect: PT90S # HTTP connect timeout for the digital twin registry client
+  discovery:
+    oAuthClientId: portal # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
+    discoveryFinderUrl: ${DIGITALTWINREGISTRY_DISCOVERY_FINDER_URL:} # The endpoint to discover EDC endpoints to a particular BPN.
+    timeout:
+      read: PT90S # HTTP read timeout for the discovery client
+      connect: PT90S # HTTP connect timeout for the discovery client
 
 semanticshub:
   # The endpoint to retrieve the json schema of a model from the semantic hub. If specified, must contain the placeholder {urn}.
@@ -234,10 +239,6 @@ ess:
   irs:
     url: "${IRS_URL:}" # IRS Url to connect with
   discovery:
-    oAuthClientId: portal # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
-    timeout:
-      read: PT90S # HTTP read timeout for the discovery client
-      connect: PT90S # HTTP connect timeout for the discovery client
     mockEdcResult: { } # Mocked BPN Investigation results
     mockRecursiveEdcAsset: # Mocked BPN Recursive Investigation results
 

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/configuration/JsonLdConfiguration.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/configuration/JsonLdConfiguration.java
@@ -34,7 +34,6 @@ import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -53,6 +52,7 @@ public class JsonLdConfiguration {
     public static final String NAMESPACE_EDC_ID = NAMESPACE_EDC + "id";
     public static final String NAMESPACE_TRACTUSX = "https://w3id.org/tractusx/v0.0.1/ns/";
     public static final String NAMESPACE_DCT = "https://purl.org/dc/terms/";
+    public static final String JSON_LD_OBJECT_MAPPER = "jsonLdObjectMapper";
 
     @Bean /* package */ TitaniumJsonLd titaniumJsonLd(final Monitor monitor) {
         final TitaniumJsonLd titaniumJsonLd = new TitaniumJsonLd(monitor);
@@ -69,8 +69,7 @@ public class JsonLdConfiguration {
         return new ConsoleMonitor();
     }
 
-    @Bean
-    @Qualifier("jsonLdObjectMapper")
+    @Bean(JSON_LD_OBJECT_MAPPER)
         /* package */ ObjectMapper objectMapper() {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/EdcTransformer.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/transformer/EdcTransformer.java
@@ -23,6 +23,8 @@
  ********************************************************************************/
 package org.eclipse.tractusx.irs.edc.client.transformer;
 
+import static org.eclipse.tractusx.irs.edc.client.configuration.JsonLdConfiguration.JSON_LD_OBJECT_MAPPER;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -84,7 +86,7 @@ public class EdcTransformer {
     private final TitaniumJsonLd titaniumJsonLd;
     private final TransformerContextImpl transformerContext;
 
-    public EdcTransformer(@Qualifier("jsonLdObjectMapper") final ObjectMapper objectMapper,
+    public EdcTransformer(@Qualifier(JSON_LD_OBJECT_MAPPER) final ObjectMapper objectMapper,
             final TitaniumJsonLd titaniumJsonLd) {
         this.titaniumJsonLd = titaniumJsonLd;
         final JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(Map.of());


### PR DESCRIPTION
- Updated configuration of `DISCOVERY_REST_TEMPLATE` from `ess.discovery.*` to `digitalTwinRegistry.discovery.*` and discovery finder URL from `digitalTwinRegistry.discoveryFinderUrl` to `digitalTwinRegistry.discovery.discoveryFinderUrl`
- Fixed Bugs found by Sonar regarding bean creation