### PR TITLE
Chore/#367 industry core changes

### DIFF
--- a/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
+++ b/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
@@ -37,20 +37,17 @@ The product IRS MUST align with the Industry Code Standard CX-126 and CX-127.
 
 ## Version matrix
 
-| Artefact                   | Version | Availability                                        | link                                                                                                                                              |
-|----------------------------|---------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| AAS                        |         |                                                     |                                                                                                                                                   |
-| PartAsPlanned              | 1.0.1   | Mandatory                                           | [PartAsPlanned 1.0.1](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.part_as_planned/1.0.1)                        |
-| PartAsPlanned              | 2.0.0   | Optional (Mandatory for next version of CX-0126)    | [PartAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.part_as_planned/2.0.0)                        |
-| SingleLevelBomAsPlanned    | 1.1.0   | Mandatory                                           | [SingleLevelBomAsPlanned 1.1.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_planned/1.1.0)] |
-| SingleLevelBomAsPlanned    | 2.0.0   | Optional (Mandatory for next version of CX-0126)    | [SingleLevelBomAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_planned/2.2.0)] |
-| SerialPart                 | 1.0.1   | Mandatory                                           | [SerialPart 1.0.1](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.serial_part/1.0.1)                               |
-| SerialPart                 | 2.0.0   | Optional                                            | [SerialPart 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.serial_part/2.0.0)                               |
-| Batch                      | 2.0.0   | Mandatory                                           | [Batch 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.batch/2.0.0)                                          |
-| Batch                      | 2.0.1   | Optional                                            | [Batch 2.0.1](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.batch/2.0.1)                                          |
-| JustInSequencePart         | 2.0.0   | Optional                                            | [JustInSequencePart 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.just_in_sequence_part/2.0.0)             |
-| SingleLevelBomAsBuilt      | 2.0.0   | Mandatory                                           | [SingleLevelBomAsBuilt 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_built/2.0.0)      |
-| PartSiteInformationAsBuilt | 1.0.0   | Integrated in Aspects JustInSequencePart / Batch / SerialPart | https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.shared.part_site_information_as_built/1.0.0                                                                                                                                               |
+
+|Artefact| Version | Availability                                                 | link                                                                                                                                              |
+|---|---------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| AAS |         |                                                              |                                                                                                                                                   |
+|PartAsPlanned | 2.0.0   | Mandatory             | [PartAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.part_as_planned/2.0.0)                        |
+| SingleLevelBomAsPlanned| 2.0.0   | Mandatory              | [SingleLevelBomAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_planned/2.2.0)  |
+| SerialPart| 3.0.0   | Mandatory                                                    | [SerialPart 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.serial_part/3.0.0/gen)                           |
+| Batch| 3.0.0   | Mandatory                                                    | [Batch 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.batch/3.0.0)                                          |
+| JustInSequencePart| 3.0.0   | Mandatory                                                     | [JustInSequencePart 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.just_in_sequence_part/3.0.0)             |
+| SingleLevelBomAsBuilt| 2.0.0   | Mandatory                                                    | [SingleLevelBomAsBuilt 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_built/2.0.0)      |
+| PartSiteInformationAsBuilt| 1.0.0   | Integrated in Aspects JustInSequencePart / Batch / SerialPart | https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.shared.part_site_information_as_built/1.0.0                         |
 
 
 - JustInSequencePart:  https://github.com/eclipse-tractusx/sldt-semantic-models/pull/563

--- a/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
+++ b/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
@@ -42,12 +42,12 @@ The product IRS MUST align with the Industry Code Standard CX-126 and CX-127.
 |---|---------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | AAS |         |                                                              |                                                                                                                                                   |
 |PartAsPlanned | 2.0.0   | Mandatory             | [PartAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.part_as_planned/2.0.0)                        |
-| SingleLevelBomAsPlanned| 2.0.0   | Mandatory              | [SingleLevelBomAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_planned/2.2.0)  |
-| SerialPart| 3.0.0   | Mandatory                                                    | [SerialPart 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.serial_part/3.0.0/gen)                           |
+| SingleLevelBomAsPlanned| 2.0.0   | Mandatory              | [SingleLevelBomAsPlanned 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_planned/2.0.0)  |
+| SerialPart| 3.0.0   | Mandatory                                                    | [SerialPart 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.serial_part/3.0.0)                           |
 | Batch| 3.0.0   | Mandatory                                                    | [Batch 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.batch/3.0.0)                                          |
 | JustInSequencePart| 3.0.0   | Mandatory                                                     | [JustInSequencePart 3.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.just_in_sequence_part/3.0.0)             |
 | SingleLevelBomAsBuilt| 2.0.0   | Mandatory                                                    | [SingleLevelBomAsBuilt 2.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_bom_as_built/2.0.0)      |
-| PartSiteInformationAsBuilt| 1.0.0   | Integrated in Aspects JustInSequencePart / Batch / SerialPart | https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.shared.part_site_information_as_built/1.0.0                         |
+| PartSiteInformationAsBuilt| 1.0.0   | Integrated in Aspects JustInSequencePart / Batch / SerialPart | [PartSiteInformationAsBuilt 1.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.shared.part_site_information_as_built/1.0.0)                         |
 
 
 - JustInSequencePart:  https://github.com/eclipse-tractusx/sldt-semantic-models/pull/563

--- a/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
+++ b/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
@@ -72,6 +72,9 @@ The product IRS MUST align with the Industry Code Standard CX-126 and CX-127.
 For serialized parts, batches, and JIS parts this will be deprecated with new version 3.x.x of AAS.
 ASS parameter assetLifecyclePhase will not be used anymore to detect BOMLifecycle. Parameter  'digitalTwinType' is used instead.
 
+**assetLifecyclePhase is not used to detect BomLifecyle any more.**
+
+
 ### Use parameter 'digitalTwinType' to detect  BOMLifecycle
 
 **Parameter 'digitalTwinType'**
@@ -99,17 +102,9 @@ alt aas contains 'digitalTwinType'
     else digitalTwinType any other value or null
        BOMLifecycleDetector -->>  IRS : throw Exception
     end
-else   aas contains 'assetLifecyclePhase'
-   alt assetLifecyclePhase="AsBuilt"
-        BOMLifecycleDetector -->>  IRS : return asBuilt  
-   else assetLifecyclePhase="AsPlanned"
-        BOMLifecycleDetector -->>  IRS : return asPlanned
-   else assetLifecyclePhase any other value or null
-        BOMLifecycleDetector -->>  IRS :   throw Exception
-   end
 else
    IRS -->> BOMLifecycleDetector : throw Exception (BOMLifecylce could not be detected)
-   BOMLifecycleDetector -->> IRS : retrun BOMLifecyle
+   BOMLifecycleDetector -->> IRS : return BOMLifecyle
 end   
 
 ````

--- a/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
+++ b/docs/concept/#367-adapt-to-changes-of-industry-core/#367-adapt-to-changes-industry-core.md
@@ -111,13 +111,14 @@ end
 
 #### Configuration of parameter 'digitalTwinType'
 Parameter is configurable for dDTR instance and has to be configured for integration test.
+Setup dDTR registry on used environments. INT, DEV, PEN, STABLE 
 
 - [Values.yaml](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/f438fe96a7ae1f1b920e8e4fb4114fb7af32643d/charts/registry/values.yaml#L51)
 - [README.md](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/f438fe96a7ae1f1b920e8e4fb4114fb7af32643d/charts/registry/README.md#:~:text=externalSubjectIdWildcardAllowedTypes)
 
 values.yaml
 ````json
-   registry.externalSubjectIdWildcardAllowedTypes = manufacturerPartId,assetLifecyclePhase,digitalTwinType
+   registry.externalSubjectIdWildcardAllowedTypes = manufacturerPartId,digitalTwinType
 ````
 
 
@@ -181,7 +182,7 @@ values.yaml
 |manufacturerId | Mandatory                                | The Business Partner Number (BPNL) of the manufacturer of the part.                                                                                                                                                                                   |
 |manufacturerPartId | Mandatory                                |                                                                                                                                                                                                                                                       |
 |customerPartId | Optional                                 |                                                                                                                                                                                                                                                       |
-|assetLifecyclePhase | asPlanned(Mandatory) / asBuilt(Optional) | @Deprecated For serialized parts, batches, and JIS parts, use the value AsBuilt. For catalog parts in a Digital Twin As-Planned lifecycle phase, use the value AsPlanned.                                                                             |
+|assetLifecyclePhase | asPlanned(Mandatory) / asBuilt(Optional) | @Deprecated Not used any more. For serialized parts, batches, and JIS parts, use the value AsBuilt. For catalog parts in a Digital Twin As-Planned lifecycle phase, use the value AsPlanned.                                                          |
 |digitalTwinType | Mandatory                                | digitalTwinType="PartType" OR digitalTwinType="PartInstance" For parts on an instance level (e.g. serialized parts, batches, and JIS parts), use the value PartInstance. For parts on a part type level (e.g. catalog parts), use the value PartType. |                                                                                                                                                                       | |
 
 # PartAsPlanned


### PR DESCRIPTION
assetLifecyclePhase is deprecated and not supported in 24.5 any more, 