### PR TITLE
chore(collection):[#TRI-996] Correct param "jobStates" in collection …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - Added role "admin_irs" again
 
 ### Changed
-- Deprecated query parameter 'jobStates' was removed from GET {{IRS_HOST}}/irs/jobs endpoint
+- Deprecated query parameter 'jobStates' was removed from GET {{IRS_HOST}}/irs/jobs endpoint. TRI-996
 - Moved OAuth2 JWT token claim to configuration. The fields can be configured with `oauth.resourceClaim`, `oauth.irsNamespace`, `oauth.roles`.
 - ESS
   - Added Tombstone to ESS investigation in case required aspect models "PartAsPlanned" or "PartSiteInformationAsPlanned" are missing

--- a/docs/src/uml-diagrams/irs-recursive/use-case-esr-certificate/esr-certificate-sequence-irs.puml
+++ b/docs/src/uml-diagrams/irs-recursive/use-case-esr-certificate/esr-certificate-sequence-irs.puml
@@ -29,7 +29,7 @@ ref over IRS, DTRegistry, DAPS, "SubmodelServer AssemblyPartRelationship)"
 end ref
 
 loop 100 times
-    ESRSubServer --> IRS: GET /irs/jobs?jobStates=COMPLETED
+    ESRSubServer --> IRS: GET /irs/jobs?states=COMPLETED
     ESRSubServer <-- IRS: jobList
     alt jobId is in jobList
         ESRSubServer --> IRS: GET /irs/jobs{jobId}

--- a/local/testing/request-collection/IRS_Request_Collection.json
+++ b/local/testing/request-collection/IRS_Request_Collection.json
@@ -1384,7 +1384,7 @@
 			"body": {},
 			"parameters": [
 				{
-					"name": "jobStates",
+					"name": "states",
 					"value": "COMPLETED",
 					"disabled": false
 				}
@@ -1425,7 +1425,7 @@
 			"body": {},
 			"parameters": [
 				{
-					"name": "jobStates",
+					"name": "states",
 					"value": "ERROR",
 					"disabled": false
 				}
@@ -1466,7 +1466,7 @@
 			"body": {},
 			"parameters": [
 				{
-					"name": "jobStates",
+					"name": "states",
 					"value": "INITIAL",
 					"disabled": false
 				}
@@ -1542,7 +1542,7 @@
 			"body": {},
 			"parameters": [
 				{
-					"name": "jobStates",
+					"name": "states",
 					"value": "RUNNING",
 					"disabled": false
 				}
@@ -2019,20 +2019,20 @@
 			"body": {},
 			"parameters": [
 				{
-					"name": "jobStates",
+					"name": "states",
 					"value": "ERROR",
 					"disabled": true,
 					"id": "pair_c694b66f41e649db837f801b5699859e"
 				},
 				{
-					"name": "jobStates",
+					"name": "states",
 					"value": "CANCELED,COMPLETED",
 					"disabled": false,
 					"id": "pair_ab346623e5394504b7232cc40ae75bed"
 				},
 				{
 					"id": "pair_ddbccd5219944e8cac3d99249ba881e5",
-					"name": "jobStates",
+					"name": "states",
 					"value": "RUNNING",
 					"description": "",
 					"disabled": true


### PR DESCRIPTION
The parameter "jobStates" was renamed to "states", but it had been forgotten to change this in the Insomnia collectsions and in one diagram (https://jira.catena-x.net/browse/TRI-996). This PR corrects this in order to avoid confusion when (re-)setting up the insomnia collection.
