### PR TITLE
chore(env): [#534] Switch keycloak token URL (DEV, INT)

### DIFF
--- a/irs-integration-tests/src/test/resources/application-dev.yml
+++ b/irs-integration-tests/src/test/resources/application-dev.yml
@@ -15,4 +15,4 @@ spring:
 
 connection:
   base-uri: https://irs.dev.demo.catena-x.net
-  access-token-uri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+  access-token-uri: https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token

--- a/irs-integration-tests/src/test/resources/application-int.yml
+++ b/irs-integration-tests/src/test/resources/application-int.yml
@@ -15,4 +15,4 @@ spring:
 
 connection:
   base-uri: https://irs.int.demo.catena-x.net
-  access-token-uri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+  access-token-uri: https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token

--- a/local/testing/IRS_DEV_environment.json
+++ b/local/testing/IRS_DEV_environment.json
@@ -1,6 +1,6 @@
 {
 	"IRS_HOST": "https://irs.dev.demo.catena-x.net",
-	"OAUTH2_TOKEN_URL": "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token",
+	"OAUTH2_TOKEN_URL": "https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token ",
 	"CLIENT_ID": "",
 	"CLIENT_SECRET": "",
 	"ADMIN_API_KEY": "",

--- a/local/testing/IRS_DEV_environment.json
+++ b/local/testing/IRS_DEV_environment.json
@@ -1,6 +1,6 @@
 {
 	"IRS_HOST": "https://irs.dev.demo.catena-x.net",
-	"OAUTH2_TOKEN_URL": "https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token ",
+	"OAUTH2_TOKEN_URL": "https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token",
 	"CLIENT_ID": "",
 	"CLIENT_SECRET": "",
 	"ADMIN_API_KEY": "",

--- a/local/testing/IRS_INT_environment.json
+++ b/local/testing/IRS_INT_environment.json
@@ -1,6 +1,6 @@
 {
 	"IRS_HOST": "https://irs.int.demo.catena-x.net",
-	"OAUTH2_TOKEN_URL": "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token",
+	"OAUTH2_TOKEN_URL": "https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token ",
 	"CLIENT_ID": "",
 	"CLIENT_SECRET": "",
 	"ADMIN_API_KEY": "",

--- a/local/testing/IRS_INT_environment.json
+++ b/local/testing/IRS_INT_environment.json
@@ -1,6 +1,6 @@
 {
 	"IRS_HOST": "https://irs.int.demo.catena-x.net",
-	"OAUTH2_TOKEN_URL": "https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token ",
+	"OAUTH2_TOKEN_URL": "https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token",
 	"CLIENT_ID": "",
 	"CLIENT_SECRET": "",
 	"ADMIN_API_KEY": "",


### PR DESCRIPTION
Migration to new "old" keyloak url Token URL: https://centralidp-v2.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token