### PR TITLE
Added job cancellation capability for IRS

### DIFF
--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
@@ -78,7 +78,7 @@ public class AASTransferProcessManager implements TransferProcessManager<ItemDat
         preExecutionHandler.accept(processId);
 
         if (Thread.currentThread().isInterrupted()) {
-            log.info("Returning from initiateRequest due to interrupt");
+            log.debug("Returning from initiateRequest due to interrupt");
 
             return new TransferInitiateResponse(processId, ResponseStatus.NOT_STARTED_JOB_CANCELLED);
         }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
@@ -26,9 +26,9 @@ package org.eclipse.tractusx.irs.aaswrapper.job;
 import static org.eclipse.tractusx.irs.configuration.JobConfiguration.JOB_BLOB_PERSISTENCE;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -61,7 +61,7 @@ public class AASTransferProcessManager implements TransferProcessManager<ItemDat
     private final AbstractDelegate abstractDelegate;
 
     @Getter
-    private final Map<String, Future<?>> futures = new HashMap<>();
+    private final Map<String, Future<?>> futures = new ConcurrentHashMap<>();
 
     public AASTransferProcessManager(final AbstractDelegate abstractDelegate, final ExecutorService executor,
             @Qualifier(JOB_BLOB_PERSISTENCE) final BlobPersistence blobStore) {

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/aaswrapper/job/AASTransferProcessManager.java
@@ -75,15 +75,13 @@ public class AASTransferProcessManager implements TransferProcessManager<ItemDat
             final Consumer<String> preExecutionHandler, final Consumer<AASTransferProcess> completionCallback,
             final JobParameter jobData) {
         final String processId = UUID.randomUUID().toString();
+        preExecutionHandler.accept(processId);
+
         if (Thread.currentThread().isInterrupted()) {
-            log.info("{} returning from initiateRequest due to interrupt, didn't add new transfer",
-                    Thread.currentThread().getName().toUpperCase());
+            log.info("Returning from initiateRequest due to interrupt");
 
             return new TransferInitiateResponse(processId, ResponseStatus.NOT_STARTED_JOB_CANCELLED);
         }
-
-        preExecutionHandler.accept(processId);
-
         final Future<?> future = executor.submit(getRunnable(dataRequest, completionCallback, processId, jobData));
         futures.put(processId, future);
 

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
@@ -220,8 +220,8 @@ public abstract class BaseJobStore implements JobStore {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            log.info("Write lock interrupted, most likely due to job cancellation", e);
+            log.info("{} returning from writeLock due to interrupt", Thread.currentThread().getName().toUpperCase());
+            return null;
         }
-        return null;
     }
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
@@ -220,7 +220,8 @@ public abstract class BaseJobStore implements JobStore {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new JobException("Job Interrupted", e);
+            log.info("Write lock interrupted, most likely due to job cancellation", e);
         }
+        return null;
     }
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/BaseJobStore.java
@@ -220,7 +220,7 @@ public abstract class BaseJobStore implements JobStore {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            log.info("{} returning from writeLock due to interrupt", Thread.currentThread().getName().toUpperCase());
+            log.debug("Returning from writeLock due to interrupt");
             return null;
         }
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobException.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/JobException.java
@@ -56,6 +56,15 @@ public class JobException extends RuntimeException {
                                          .build();
     }
 
+    public JobException(final String message, final String detail) {
+        super(message);
+        jobErrorDetails = JobErrorDetails.builder()
+                                         .exception(message)
+                                         .errorDetail(detail)
+                                         .exceptionDate(ZonedDateTime.now(ZoneOffset.UTC))
+                                         .build();
+    }
+
     public JobException(final String message, final Throwable cause) {
         super(message, cause);
         jobErrorDetails = JobErrorDetails.builder()

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/ResponseStatus.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/ResponseStatus.java
@@ -29,5 +29,6 @@ package org.eclipse.tractusx.irs.connector.job;
 public enum ResponseStatus {
     OK,
     ERROR_RETRY,
-    FATAL_ERROR;
+    FATAL_ERROR,
+    NOT_STARTED_JOB_CANCELLED
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcessManager.java
@@ -36,7 +36,6 @@ import org.eclipse.tractusx.irs.component.JobParameter;
 public interface TransferProcessManager<T extends DataRequest, P extends TransferProcess> {
 
     String CANCELLATION_IMPOSSIBLE_FUTURE_NOT_FOUND = "Cancellation impossible for transfer process %s: Future not found";
-    String CANCELLATION_IMPOSSIBLE_TASK_DONE = "Cancellation impossible for transfer process %s: Task already done";
     String CANCELLATION_FAILED = "Cancellation failed for transfer process %s";
 
     /**

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcessManager.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/connector/job/TransferProcessManager.java
@@ -35,6 +35,10 @@ import org.eclipse.tractusx.irs.component.JobParameter;
  */
 public interface TransferProcessManager<T extends DataRequest, P extends TransferProcess> {
 
+    String CANCELLATION_IMPOSSIBLE_FUTURE_NOT_FOUND = "Cancellation impossible for transfer process %s: Future not found";
+    String CANCELLATION_IMPOSSIBLE_TASK_DONE = "Cancellation impossible for transfer process %s: Task already done";
+    String CANCELLATION_FAILED = "Cancellation failed for transfer process %s";
+
     /**
      * Starts a data request asynchronously.
      *
@@ -46,4 +50,6 @@ public interface TransferProcessManager<T extends DataRequest, P extends Transfe
      */
     TransferInitiateResponse initiateRequest(T dataRequest, Consumer<String> transferProcessStarted,
             Consumer<P> transferProcessCompleted, JobParameter jobData);
+
+    void cancelRequest(String processId);
 }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryService.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryService.java
@@ -208,11 +208,15 @@ public class IrsItemGraphQueryService implements IIrsItemGraphQueryService {
     public Job cancelJobById(final @NonNull UUID jobId) {
         final String idAsString = String.valueOf(jobId);
 
-        final Optional<MultiTransferJob> canceled = this.jobStore.cancelJob(idAsString);
-        canceled.ifPresent(cancelledJob -> applicationEventPublisher.publishEvent(
-                new JobProcessingFinishedEvent(cancelledJob.getJobIdString(), cancelledJob.getJob().getState().name(),
-                        cancelledJob.getJobParameter().getCallbackUrl(), cancelledJob.getBatchId())));
-        return canceled.orElseThrow(
+        final Optional<MultiTransferJob> cancelled = this.jobStore.cancelJob(idAsString);
+        cancelled.ifPresent(cancelledJob -> {
+            orchestrator.cancelJob(cancelledJob);
+            applicationEventPublisher.publishEvent(new JobProcessingFinishedEvent(cancelledJob.getJobIdString(),
+                    cancelledJob.getJob().getState().name(), cancelledJob.getJobParameter().getCallbackUrl(),
+                    cancelledJob.getBatchId()));
+        });
+
+        return cancelled.orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No job exists with id " + jobId)).getJob();
     }
 

--- a/irs-api/src/main/resources/log4j2.xml
+++ b/irs-api/src/main/resources/log4j2.xml
@@ -25,6 +25,7 @@
         <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="warn" />
         <Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
         <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
+        <Logger name="okhttp3.OkHttpClient" level="trace" />
     </Loggers>
 
 </Configuration>

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/services/IrsItemGraphQueryServiceTest.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 
 import org.eclipse.tractusx.irs.aaswrapper.job.AASTransferProcess;
 import org.eclipse.tractusx.irs.aaswrapper.job.ItemContainer;
+import org.eclipse.tractusx.irs.aaswrapper.job.ItemDataRequest;
 import org.eclipse.tractusx.irs.common.persistence.BlobPersistence;
 import org.eclipse.tractusx.irs.common.persistence.BlobPersistenceException;
 import org.eclipse.tractusx.irs.component.Job;
@@ -46,6 +47,7 @@ import org.eclipse.tractusx.irs.component.Jobs;
 import org.eclipse.tractusx.irs.component.PageResult;
 import org.eclipse.tractusx.irs.component.Relationship;
 import org.eclipse.tractusx.irs.component.enums.JobState;
+import org.eclipse.tractusx.irs.connector.job.JobOrchestrator;
 import org.eclipse.tractusx.irs.connector.job.JobStore;
 import org.eclipse.tractusx.irs.connector.job.MultiTransferJob;
 import org.eclipse.tractusx.irs.semanticshub.AspectModel;
@@ -79,6 +81,9 @@ class IrsItemGraphQueryServiceTest {
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private JobOrchestrator<ItemDataRequest, AASTransferProcess> orchestrator;
 
     @InjectMocks
     private IrsItemGraphQueryService testee;


### PR DESCRIPTION
### Job cancellation in IRS using Java interrupts

This PR addresses issue https://github.com/eclipse-tractusx/item-relationship-service/issues/411.

- AASTransferProcessManager

  - When a new thread is taken from the thread pool to execute a new transfer process, instead of using `execute`, the code now calls `submit` for the created Runnable. This returns a Future, which is then stored in a ConcurrentHashMap. The map's keys are the uuid strings of the transfer processes, thus making it possible to associate a transfer process id with the task it represents.

  - To make use of this, there is now a `cancelRequest` method which retrieves a Future from the map using a transfer process uuid string argument.  Then, `cancel(true)` is called on that Future, which sets the interrupt flag for the thread executing the transfer process. Afterwards, the entry for that transfer process is removed from the map.

  - Before initiating a request, this interrupt flag is checked. If it is set, the transfer process is not started and a `TransferInitiateResponse` is returned with a newly added `ResponseStatus` of `NOT_STARTED_JOB_CANCELLED`.

  - In case of the unhappy path, where the map somehow doesn't contain an entry for a transfer process or something goes wrong when setting the interrupt flag, `JobException`s  are created using a newly added constructor. This constructor allows for directly setting the error detail.

- JobOrchestrator

  - A `cancelJob` method has been added which is called when the IRS receives a job cancellation request. It uses a passed MultiTransferJob argument to get all transfer process ids for the job that is to be cancelled and iterates over the collection of ids calling AASTransferProcessManager's `cancelRequest` method. In each iteration, if `cancelRequest` throws a `JobException`, the method evaluates what happened based on the error detail that was specified when creating the Exception in `cancelRequest`. This detail is then used to construct an error message, which is uploaded to the job store using `markJobInError`.

- BaseJobStore's `writeLock` now reliably triggers an InterruptedException, which allows to cancel any change to a job from one of the interrupted threads running the transfer processes.

- IrsItemGraphQueryService's `cancelJobById` now calls `cancelJob` in JobOrchestrator.

- Unit tests for AASTransferProcessManager and JobOrchestrator have been modified accordingly.

⚠️ `IrsWireMockIntegrationTest` does **not** have tests for this new functionality yet.